### PR TITLE
integration: allow for some padding in woodpeckerRun.

### DIFF
--- a/test/integration_test.go
+++ b/test/integration_test.go
@@ -109,8 +109,8 @@ func woodpeckerRun(conf woodpecker.Config, fetchIterations int) (string, string,
 
 	// Sleep for the right amount of time based on the fetchInterval and the
 	// requested number of iterations.
-	jitter := time.Millisecond * 20
-	time.Sleep(fetchInterval*time.Duration(fetchIterations) + jitter)
+	padding := time.Millisecond * 20
+	time.Sleep(fetchInterval*time.Duration(fetchIterations) + padding)
 
 	// Collect metrics from the woodpecker instance while it is still running
 	metricsData := getWoodpeckerMetrics("http://localhost:1971")

--- a/test/integration_test.go
+++ b/test/integration_test.go
@@ -10,6 +10,7 @@ import (
 	"net/http"
 	"os"
 	"regexp"
+	"strconv"
 	"strings"
 	"sync"
 	"testing"
@@ -107,8 +108,9 @@ func woodpeckerRun(conf woodpecker.Config, fetchIterations int) (string, string,
 	woodpecker.Run()
 
 	// Sleep for the right amount of time based on the fetchInterval and the
-	// requested number of iterations
-	time.Sleep(fetchInterval * time.Duration(fetchIterations))
+	// requested number of iterations.
+	jitter := time.Millisecond * 20
+	time.Sleep(fetchInterval*time.Duration(fetchIterations) + jitter)
 
 	// Collect metrics from the woodpecker instance while it is still running
 	metricsData := getWoodpeckerMetrics("http://localhost:1971")
@@ -219,9 +221,9 @@ func TestFetchSTHSuccess(t *testing.T) {
 	for i, srv := range testServers {
 		// Check how many times each log's STH was fetched by the monitor
 		sthFetches := srv.STHFetches()
-		// We expect each log had its STH fetched twice: Once at startup, and once
-		// for each of the iterations elapsed.
-		if sthFetches != int64(iterations+1) {
+		// We expect a certain minimum number of fetches based on the iterations. If
+		// there were *more* fetches that's OK, the test probably ran a little long.
+		if sthFetches < int64(iterations+1) {
 			t.Errorf("Expected %d sth fetches for log %q, got %d",
 				(iterations + 1), srv.Addr, sthFetches)
 		}
@@ -235,13 +237,20 @@ func TestFetchSTHSuccess(t *testing.T) {
 				expectedTimestampLine, metricsData)
 		}
 
-		// Check that each log has the expected STH latency count
-		expectedLatencyCount := iterations
-		expectedLatencyCountLine := fmt.Sprintf(`sth_latency_count{uri="http://localhost%s"} %d`,
-			srv.Addr, expectedLatencyCount)
-		if !strings.Contains(metricsData, expectedLatencyCountLine) {
-			t.Errorf("Could not find expected metrics line %q in metrics output: \n%s\n",
-				expectedLatencyCountLine, metricsData)
+		// Check that each log has the minimum expected STH latency count. If there
+		// were more latency submissions than expected that's OK, the test probably
+		// ran a little long.
+		expectedLatencyCountRegexp := regexp.MustCompile(
+			fmt.Sprintf(`sth_latency_count{uri="http://localhost%s"} ([\d]+)`,
+				srv.Addr))
+		expectedLatencyCount := iterations + 1
+		if matches := expectedLatencyCountRegexp.FindStringSubmatch(metricsData); len(matches) < 2 {
+			t.Errorf("Could not find expected sth_latency_count line in metrics output: \n%s\n",
+				metricsData)
+		} else if latencyCount, err := strconv.Atoi(matches[1]); err != nil {
+			t.Errorf("sth_latency_count for log %s had non-numeric value", srv.Addr)
+		} else if latencyCount < expectedLatencyCount {
+			t.Errorf("expected sth_latency_count of %d for log %s, found %d", expectedLatencyCount, srv.Addr, latencyCount)
 		}
 
 		// Check that each log has the expected STH age in the metrics output


### PR DESCRIPTION
Prior to this commit `woodpeckerRun` let a woodpecker instance under
test run for _exactly_ the time required to do a fixed number of
monitoring iterations based on the configured STH fetch interval. In
practice we can't expect the monitors to complete in exactly that amount
of time every time. This commit oversleeps for 20ms to ensure that minor
scheduling differences in the monitor goroutines don't cause the test to
fail. This resolves the failures where the monitor was killed early and
did not complete its expected work. Running integration tests in a tight
loop locally with this fix applied showed no failures.

Unfortunately the above is not enough to fix all CI failures and so this
commit also loosens the `sth_latency_count` and expected number of STH
fetch tests to accept over-checking the STH (e.g. because the test ran
longer than expected before killing the woodpecker instance).

In practice the combination of these two fixes results in 10/10 test
builds passing. Prior to these fixes only ~6-7/10 of builds pass.