### PR TITLE
Monitor: Support submitting precerts.

### DIFF
--- a/monitor/cert_submitter.go
+++ b/monitor/cert_submitter.go
@@ -158,7 +158,8 @@ func (c certSubmitter) submitCertificate(cert *x509.Certificate, isPreCert bool)
 		{Data: cert.Raw},
 	}
 
-	// Precert submissions also need the issuer in the chain
+	// Precert submissions also need the issuer in the chain because the SCT for
+	// for precerts can contain the issuer SPKI.
 	if isPreCert {
 		chain = append(chain, ct.ASN1Cert{Data: c.certIssuer.Raw})
 	}

--- a/monitor/cert_submitter.go
+++ b/monitor/cert_submitter.go
@@ -48,7 +48,7 @@ var (
 )
 
 // SubmitterOptions is a struct holding options related to issuing and
-// submitting certificates to the monitored log peridoically.
+// submitting certificates to the monitored log periodically.
 type SubmitterOptions struct {
 	// Interval describes the duration that the monitor will sleep between
 	// submitting certificates to the monitored log.

--- a/monitor/cert_submitter.go
+++ b/monitor/cert_submitter.go
@@ -4,8 +4,10 @@ import (
 	"context"
 	"crypto/ecdsa"
 	"crypto/x509"
+	"errors"
 	"fmt"
 	"log"
+	"strconv"
 	"time"
 
 	ct "github.com/google/certificate-transparency-go"
@@ -37,16 +39,52 @@ var (
 			Name:    "cert_submit_latency",
 			Help:    "Latency submitting certificate chains to CT logs",
 			Buckets: internetFacingBuckets,
-		}, []string{"uri"}),
+		}, []string{"uri", "precert"}),
 		certSubmitResults: promauto.NewCounterVec(prometheus.CounterOpts{
 			Name: "cert_submit_results",
 			Help: "Count of results from submitting certificate chains to CT logs, sliced by status",
-		}, []string{"uri", "status"}),
+		}, []string{"uri", "status", "precert"}),
 	}
 )
 
+// SubmitterOptions is a struct holding options related to issuing and
+// submitting certificates to the monitored log peridoically.
+type SubmitterOptions struct {
+	// Interval describes the duration that the monitor will sleep between
+	// submitting certificates to the monitored log.
+	Interval time.Duration
+	// IssuerKey is the ECDSA private key used to sign issued certificates
+	IssuerKey *ecdsa.PrivateKey
+	// IssuerCert is the issuer certificate used to issue certificates submitted
+	// to the monitored log. Its public key must correspond to the private key in
+	// IssuerKey
+	IssuerCert *x509.Certificate
+	// SubmitPreCert controls whether or not precertificates are submitted
+	SubmitPreCert bool
+	// SubmitCert controls whether or not final certificates are submitted
+	SubmitCert bool
+}
+
+// Valid checks that the SubmitterOptions has a valid positive interval and that
+// the IssuerKey and IssuerCert are not nil.
+func (o SubmitterOptions) Valid() error {
+	if o.Interval <= 0 {
+		return errors.New("Submitter interval must be > 0")
+	}
+
+	if o.IssuerKey == nil {
+		return errors.New("IssuerKey must not be nil")
+	}
+
+	if o.IssuerCert == nil {
+		return errors.New("IssuerCert must not be nil")
+	}
+
+	return nil
+}
+
 // certSubmitter is a type for periodically issuing certificates and submitting
-// them to a log's add-chain endpoint.
+// them to a log's add-chain and add-pre-chain endpoints.
 type certSubmitter struct {
 	logger *log.Logger
 	clk    clock.Clock
@@ -60,6 +98,10 @@ type certSubmitter struct {
 	certIssuerKey *ecdsa.PrivateKey
 	// Certificate used as the issuer for certificates submitted to the log.
 	certIssuer *x509.Certificate
+	// Should a precert be submitted?
+	submitPreCert bool
+	// Should a final cert be submitted?
+	submitCert bool
 }
 
 // run starts a goroutine that calls submitCertificate, sleeps for
@@ -67,7 +109,7 @@ type certSubmitter struct {
 func (c *certSubmitter) run() {
 	go func() {
 		for {
-			c.submitCertificate()
+			c.submitCertificates()
 			c.logger.Printf("Sleeping for %s before next certificate submission\n",
 				c.certSubmitInterval)
 			c.clk.Sleep(c.certSubmitInterval)
@@ -75,48 +117,72 @@ func (c *certSubmitter) run() {
 	}()
 }
 
-// submitCertificate issues a certificate with the certSubmitter's
-// certIssuer/certIssuerKey and submits it to a monitored log's add-chain
-// endpoint. The latency of the submission is tracked in the
-// `cert_submit_latency` prometheus histogram. If the submission fails, or the
-// returned SCT is invalid the `cert_submit_results` prometheus countervec is
-// incremented with a "fail" status tag. If the submission succeeds the
-// `cert_submit_results` prometheus countervec is incremented with a "ok" status
-// tag. An SCT is considered invalid if the signature does not validate, or if
-// the timestamp is too far in the future or the past (controlled by
-// `requiredSCTFreshness`).
-func (c *certSubmitter) submitCertificate() {
+// submitCertificates issues a pre-certificate and a matching certificate with
+// the certSubmitter's certIssuer/certIssuerKey. If `submitPreCert` is enabled
+// then a precert is submitted. If `submitCert` is enabled then a final cert is
+// submitted.
+func (c *certSubmitter) submitCertificates() {
 	// a certSubmitter requires a non-nil certIssuerKey and certIssuer. If somehow
 	// was one created with nil values then panic.
 	if c.certIssuerKey == nil || c.certIssuer == nil {
 		panic("certSubmitter created with nil certIssuerKey or certIssuer\n")
 	}
 
-	c.logger.Printf("Submitting certificate to %q\n", c.logURI)
-
-	cert, err := pki.IssueTestCertificate(c.certIssuerKey, c.certIssuer, c.clk)
+	certPair, err := pki.IssueTestCertificate(c.certIssuerKey, c.certIssuer, c.clk)
 	if err != nil {
 		// This should not occur and if it does we should abort hard
 		panic(fmt.Sprintf("!!! Error issuing certificate: %s\n", err.Error()))
 	}
 
-	// Because ct-woodpecker issues directly off of a fake root the "chain" only
-	// contains the leaf certificate we minted in issueCertificate()
+	if c.submitPreCert {
+		c.submitCertificate(certPair.PreCert, true)
+	}
+
+	if c.submitCert {
+		c.submitCertificate(certPair.Cert, false)
+	}
+}
+
+// submitCertificate submits a single x509 Certificate to a log. If `isPreCert`
+// is true then the certificate is submitted via the log's add-pre-chain
+// endpoint, otherwise the add-chain endpoint is used. The latency of the
+// submission is tracked in the `cert_submit_latency` prometheus histogram. If
+// the submission fails, or the returned SCT is invalid the
+// `cert_submit_results` prometheus countervec is incremented with a "fail"
+// status tag. If the submission succeeds the `cert_submit_results` prometheus
+// countervec is incremented with a "ok" status tag. An SCT is considered
+// invalid if the signature does not validate, or if the timestamp is too far in
+// the future or the past (controlled by `requiredSCTFreshness`).
+func (c certSubmitter) submitCertificate(cert *x509.Certificate, isPreCert bool) {
 	chain := []ct.ASN1Cert{
 		{Data: cert.Raw},
 	}
 
+	// Precert submissions also need the issuer in the chain
+	if isPreCert {
+		chain = append(chain, ct.ASN1Cert{Data: c.certIssuer.Raw})
+	}
+
+	var submissionMethod func(context.Context, []ct.ASN1Cert) (*ct.SignedCertificateTimestamp, error)
+	submissionMethod = c.client.AddChain
+	certKind := "certificate"
+	if isPreCert {
+		submissionMethod = c.client.AddPreChain
+		certKind = "precertificate"
+	}
+	c.logger.Printf("Submitting %s to %q\n", certKind, c.logURI)
+
 	start := c.clk.Now()
 	ctx, cancel := context.WithTimeout(context.Background(), submitTimeout)
 	defer cancel()
-	sct, err := c.client.AddChain(ctx, chain)
+	sct, err := submissionMethod(ctx, chain)
 	elapsed := c.clk.Since(start)
-	latencyLabels := prometheus.Labels{"uri": c.logURI}
+	latencyLabels := prometheus.Labels{"uri": c.logURI, "precert": strconv.FormatBool(isPreCert)}
 	c.stats.certSubmitLatency.With(latencyLabels).Observe(elapsed.Seconds())
 
-	failLabels := prometheus.Labels{"uri": c.logURI, "status": "fail"}
+	failLabels := prometheus.Labels{"uri": c.logURI, "status": "fail", "precert": strconv.FormatBool(isPreCert)}
 	if err != nil {
-		c.logger.Printf("!!! Error submitting certificate to %q: %s\n", c.logURI, err.Error())
+		c.logger.Printf("!!! Error submitting %s to %q: %s\n", certKind, c.logURI, err.Error())
 		c.stats.certSubmitResults.With(failLabels).Inc()
 		return
 	}
@@ -128,18 +194,18 @@ func (c *certSubmitter) submitCertificate() {
 	// future and the past. The SCT's signature & log ID have already been verified by
 	// `m.client.AddChain()`
 	if sctAge > requiredSCTFreshness {
-		c.logger.Printf("!!! Error submitting certificate to %q: returned SCT timestamp signed %s in the future (expected <= %s)",
-			c.logURI, sctAge, requiredSCTFreshness)
+		c.logger.Printf("!!! Error submitting %s to %q: returned SCT timestamp signed %s in the future (expected <= %s)",
+			certKind, c.logURI, sctAge, requiredSCTFreshness)
 		c.stats.certSubmitResults.With(failLabels).Inc()
 		return
 	} else if -sctAge > requiredSCTFreshness {
-		c.logger.Printf("!!! Error submitting certificate to %q: returned SCT timestamp signed %s in the past (expected <= %s)",
-			c.logURI, -sctAge, requiredSCTFreshness)
+		c.logger.Printf("!!! Error submitting %s to %q: returned SCT timestamp signed %s in the past (expected <= %s)",
+			certKind, c.logURI, -sctAge, requiredSCTFreshness)
 		c.stats.certSubmitResults.With(failLabels).Inc()
 		return
 	}
 
-	successLabels := prometheus.Labels{"uri": c.logURI, "status": "ok"}
+	successLabels := prometheus.Labels{"uri": c.logURI, "status": "ok", "precert": strconv.FormatBool(isPreCert)}
 	c.stats.certSubmitResults.With(successLabels).Inc()
-	c.logger.Printf("Certificate chain submitted to %q. SCT timestamp %s", c.logURI, ts)
+	c.logger.Printf("%s chain submitted to %q. SCT timestamp %s", certKind, c.logURI, ts)
 }

--- a/monitor/monitor.go
+++ b/monitor/monitor.go
@@ -48,8 +48,7 @@ type MonitorOptions struct {
 
 // Valid enforces that a MonitorOptions instance is valid. There must be
 // a non-empty LogURI and LogKey. One of FetchOpts or SubmitOpts must not be
-// non-nil and valid. If the FetchOpts are not nil, they must be valid. If the
-// SubmitOpts are not nil, they must be valid.
+// non-nil and valid.
 func (conf MonitorOptions) Valid() error {
 	if conf.LogURI == "" {
 		return errors.New("LogURI must not be empty")

--- a/monitor/monitor.go
+++ b/monitor/monitor.go
@@ -48,8 +48,8 @@ type MonitorOptions struct {
 
 // Valid enforces that a MonitorOptions instance is valid. There must be
 // a non-empty LogURI and LogKey. One of FetchOpts or SubmitOpts must not be
-// nil. If the FetchOpts are not nil, they must be valid. If the SubmitOpts are
-// not nil, they must be valid.
+// non-nil and valid. If the FetchOpts are not nil, they must be valid. If the
+// SubmitOpts are not nil, they must be valid.
 func (conf MonitorOptions) Valid() error {
 	if conf.LogURI == "" {
 		return errors.New("LogURI must not be empty")

--- a/monitor/monitor.go
+++ b/monitor/monitor.go
@@ -1,9 +1,11 @@
+// Package monitor provides the mechanisms used to monitor a single CT log. This
+// includes fetching the log STH periodically as well as issuing certificates
+// and submitting them to the log periodically.
 package monitor
 
 import (
 	"context"
-	"crypto/ecdsa"
-	"crypto/x509"
+	"errors"
 	"fmt"
 	"log"
 	"net/http"
@@ -25,9 +27,60 @@ var internetFacingBuckets = []float64{.1, .25, .5, 1, 2.5, 5, 7.5, 10, 15, 30, 4
 type monitorCTClient interface {
 	GetSTH(context.Context) (*ct.SignedTreeHead, error)
 	AddChain(context.Context, []ct.ASN1Cert) (*ct.SignedCertificateTimestamp, error)
+	AddPreChain(context.Context, []ct.ASN1Cert) (*ct.SignedCertificateTimestamp, error)
 }
 
-// Monitor is a struct for monitoring a CT log.
+// MonitorOptions is a struct for holding monitor configuration options
+type MonitorOptions struct {
+	// LogURI is the URI of the log to be monitored
+	LogURI string
+	// LogKey is the BASE64 encoded DER of the log's public key (No PEM header/footer).
+	LogKey string
+
+	// FetchOpts holds the FetcherOptions for fetching the log STH periodically.
+	// It may be nil if no STH fetching is to be performed.
+	FetchOpts *FetcherOptions
+	// SubmitOpts holds the optional SubmitterOptions for submitting certificates
+	// to the log periodically. It may be nil if no certificate submission is to
+	// be performed.
+	SubmitOpts *SubmitterOptions
+}
+
+// Valid enforces that a MonitorOptions instance is valid. There must be
+// a non-empty LogURI and LogKey. One of FetchOpts or SubmitOpts must not be
+// nil. If the FetchOpts are not nil, they must be valid. If the SubmitOpts are
+// not nil, they must be valid.
+func (conf MonitorOptions) Valid() error {
+	if conf.LogURI == "" {
+		return errors.New("LogURI must not be empty")
+	}
+
+	if conf.LogKey == "" {
+		return errors.New("LogKey must not be empty")
+	}
+
+	if conf.FetchOpts == nil && conf.SubmitOpts == nil {
+		return errors.New("One of FetchOpts or SubmitOpts must not be nil")
+	}
+
+	if conf.FetchOpts != nil {
+		if err := conf.FetchOpts.Valid(); err != nil {
+			return err
+		}
+	}
+
+	if conf.SubmitOpts != nil {
+		if err := conf.SubmitOpts.Valid(); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// Monitor is a struct for monitoring a CT log. It may fetch the log's STH
+// periodically or submit certs periodically or both depending on whether
+// fetcher and submitter are not nil.
 type Monitor struct {
 	logger *log.Logger
 	clk    clock.Clock
@@ -36,16 +89,13 @@ type Monitor struct {
 	submitter *certSubmitter
 }
 
-// New creates a Monitor for the given parameters. The b64key parameter is
-// expected to contain the PEM encoded public key used to verify the log's STH
-// _without_ the PEM header/footer.
-func New(
-	uri, b64key string,
-	sthFetchInterval, certSubmitInterval time.Duration,
-	certIssuerKey *ecdsa.PrivateKey,
-	certIssuer *x509.Certificate,
-	logger *log.Logger,
-	clk clock.Clock) (*Monitor, error) {
+// New creates a Monitor for the given options. The monitor will not be started
+// until Run() is called.
+func New(opts MonitorOptions, logger *log.Logger, clk clock.Clock) (*Monitor, error) {
+	if err := opts.Valid(); err != nil {
+		return nil, err
+	}
+
 	hc := &http.Client{
 		Timeout: time.Minute,
 	}
@@ -54,13 +104,14 @@ func New(
 	// DER. The `ctclient.New()` constructor expects a vanilla PEM block, that is,
 	// base64 encoded DER surrounded by a header/footer. We manufacture such
 	// a block here using the b64key
-	pubkey := fmt.Sprintf("-----BEGIN PUBLIC KEY-----\n%s\n-----END PUBLIC KEY-----", b64key)
+	pubkey := fmt.Sprintf("-----BEGIN PUBLIC KEY-----\n%s\n-----END PUBLIC KEY-----",
+		opts.LogKey)
 
 	// Create a CT client for the log. We pass a PublicKey in the
 	// `jsonclient.Options` to ensure that the STH signature will be validated
 	// when we call the client's `GetSTH` function. If this parameter is nil no
 	// signature check is performed.
-	client, err := ctClient.New(uri, hc, jsonclient.Options{
+	client, err := ctClient.New(opts.LogURI, hc, jsonclient.Options{
 		Logger:    logger,
 		PublicKey: pubkey,
 	})
@@ -71,37 +122,55 @@ func New(
 	m := &Monitor{
 		logger: logger,
 		clk:    clk,
+	}
 
-		fetcher: &sthFetcher{
+	if opts.FetchOpts != nil {
+		m.fetcher = &sthFetcher{
 			logger:           logger,
 			clk:              clk,
 			stats:            sthStats,
 			client:           client,
-			logURI:           uri,
-			sthFetchInterval: sthFetchInterval,
-		},
+			logURI:           opts.LogURI,
+			sthFetchInterval: opts.FetchOpts.Interval,
+		}
 	}
 
-	if certIssuerKey != nil {
+	if opts.SubmitOpts != nil {
 		m.submitter = &certSubmitter{
 			logger:             logger,
 			clk:                clk,
 			stats:              certStats,
 			client:             client,
-			logURI:             uri,
-			certSubmitInterval: certSubmitInterval,
-			certIssuer:         certIssuer,
-			certIssuerKey:      certIssuerKey,
+			logURI:             opts.LogURI,
+			certSubmitInterval: opts.SubmitOpts.Interval,
+			certIssuer:         opts.SubmitOpts.IssuerCert,
+			certIssuerKey:      opts.SubmitOpts.IssuerKey,
+			submitPreCert:      opts.SubmitOpts.SubmitPreCert,
+			submitCert:         opts.SubmitOpts.SubmitCert,
 		}
 	}
 
 	return m, nil
 }
 
+// STHFetcher returns true if the monitor is configured to fetch the monitor
+// log's STH periodically.
+func (m *Monitor) STHFetcher() bool {
+	return m.fetcher != nil
+}
+
+// CertSubmitter returns true if the monitor is configured to submit
+// certificates or precertificates to the monitored log periodically.
+func (m *Monitor) CertSubmitter() bool {
+	return m.submitter != nil
+}
+
 // Run starts the log monitoring process by starting the log's STH fetcher and
 // the cert submitter.
 func (m *Monitor) Run() {
-	m.fetcher.run()
+	if m.fetcher != nil {
+		m.fetcher.run()
+	}
 
 	if m.submitter != nil {
 		m.submitter.run()

--- a/monitor/sth_fetcher.go
+++ b/monitor/sth_fetcher.go
@@ -2,6 +2,7 @@ package monitor
 
 import (
 	"context"
+	"errors"
 	"log"
 	"time"
 
@@ -44,6 +45,21 @@ var sthStats *sthFetchStats = &sthFetchStats{
 		Help:    "Latency observing CT log signed tree head (STH)",
 		Buckets: internetFacingBuckets,
 	}, []string{"uri"}),
+}
+
+// FetcherOptions is a struct holding options for STH fetching.
+type FetcherOptions struct {
+	// Interval describes the duration that the monitor will sleep between
+	// fetching the STH.
+	Interval time.Duration
+}
+
+// Valid checks that the FetcherOptions interval is positive.
+func (o FetcherOptions) Valid() error {
+	if o.Interval <= 0 {
+		return errors.New("Fetcher interval must be >= 0")
+	}
+	return nil
 }
 
 // sthFetcher is a type for periodically fetching a log's STH and publishing

--- a/monitor/sth_fetcher_test.go
+++ b/monitor/sth_fetcher_test.go
@@ -16,11 +16,17 @@ func TestObserveSTH(t *testing.T) {
 	clk := clock.NewFake()
 	clk.Set(time.Now())
 	fetchDuration := time.Second
-	certInterval := time.Second
 	logURI := "test"
 	labels := prometheus.Labels{"uri": logURI}
 
-	m, err := New(logURI, logKey, fetchDuration, certInterval, nil, nil, l, clk)
+	m, err := New(
+		MonitorOptions{
+			LogURI: logURI,
+			LogKey: logKey,
+			FetchOpts: &FetcherOptions{
+				Interval: fetchDuration,
+			},
+		}, l, clk)
 	if err != nil {
 		t.Fatalf("Unexpected error from New(): %s", err.Error())
 	}

--- a/pki/certs.go
+++ b/pki/certs.go
@@ -1,3 +1,5 @@
+// Package pki provides helpers for creating random certificate serial numbers,
+// random private keys, and issuing test certificates.
 package pki
 
 import (
@@ -7,6 +9,7 @@ import (
 	"crypto/rand"
 	"crypto/x509"
 	"crypto/x509/pkix"
+	"encoding/asn1"
 	"encoding/hex"
 	"errors"
 	"math"
@@ -19,6 +22,22 @@ const (
 	// Domain suffix for the subject common name of certificates generated for submission
 	// to logs. The prefix will be generated randomly from the certificate serial number.
 	testCertDomain = ".woodpecker.testing.letsencrypt.org"
+)
+
+var (
+	nilSubjKeyErr    = errors.New("cannot IssueCertificate with nil subjectKey")
+	nilIssuerKeyErr  = errors.New("cannot IssueCertificate with nil issuerKey")
+	nilIssuerCertErr = errors.New("cannot IssueCertificate with nil issuerCert")
+	nilTemplateErr   = errors.New("cannot IssueCertificate with nil template")
+
+	ctPoisonExtensionID = asn1.ObjectIdentifier{1, 3, 6, 1, 4, 1, 11129, 2, 4, 3}
+	ctPoisonExtension   = pkix.Extension{
+		// OIDExtensionCTPoison is defined in RFC 6962 s3.1.
+		Id:       ctPoisonExtensionID,
+		Critical: true,
+		// ASN.1 DER NULL, Hex encoded.
+		Value: []byte{0x05, 0x00},
+	}
 )
 
 // RandSerial generates a random *bigInt to use as a certificate serial or
@@ -47,16 +66,16 @@ func IssueCertificate(
 	issuerKey *ecdsa.PrivateKey,
 	issuerCert, template *x509.Certificate) (*x509.Certificate, error) {
 	if subjectKey == nil {
-		return nil, errors.New("cannot IssueCertificate with nil subjectKey")
+		return nil, nilSubjKeyErr
 	}
 	if issuerKey == nil {
-		return nil, errors.New("cannot IssueCertificate with nil issuerKey")
+		return nil, nilIssuerKeyErr
 	}
 	if issuerCert == nil {
-		return nil, errors.New("cannot IssueCertificate with nil issuerCert")
+		return nil, nilIssuerCertErr
 	}
 	if template == nil {
-		return nil, errors.New("cannot IssueCertificate with nil template")
+		return nil, nilTemplateErr
 	}
 
 	certDER, err := x509.CreateCertificate(rand.Reader, template, issuerCert, subjectKey, issuerKey)
@@ -71,44 +90,69 @@ func IssueCertificate(
 	return cert, nil
 }
 
+// CertificatePair is a struct for holding a precertificate and a matching final
+// certificate.
+type CertificatePair struct {
+	PreCert *x509.Certificate
+	Cert    *x509.Certificate
+}
+
 // IssueTestCertificate uses the monitor's certIssuer and certIssuerKey to generate
-// a leaf-certificate that can be submitted to a log. The certificate's subject
-// common name will be a random subdomain based on the certificate serial under
-// the `testCertDomain` domain. This function creates certificates that will be
-// submitted to public logs and so while they are not issued by a trusted root
-// we try to avoid cablint errors to avoid requiring log monitors special-case
-// our submissions.
+// a precertificate and a matching final leaf-certificate that can be submitted
+// to a log.The certificate's subject common name will be a random subdomain
+// based on the certificate serial under the `testCertDomain` domain. This
+// function creates certificates that will be submitted to public logs and so
+// while they are not issued by a trusted root  we try to avoid cablint errors
+// to avoid requiring log monitors special-case our submissions.
 func IssueTestCertificate(
 	issuerKey *ecdsa.PrivateKey,
 	issuerCert *x509.Certificate,
-	clk clock.Clock) (*x509.Certificate, error) {
+	clk clock.Clock) (CertificatePair, error) {
 
 	certKey, err := RandKey()
 	if err != nil {
-		return nil, err
+		return CertificatePair{}, err
 	}
 	serial, err := RandSerial()
 	if err != nil {
-		return nil, err
+		return CertificatePair{}, err
 	}
 
 	domain := hex.EncodeToString(serial.Bytes()[:5]) + testCertDomain
 
-	template := &x509.Certificate{
-		Subject: pkix.Name{
-			CommonName: domain,
-		},
-		DNSNames:              []string{domain},
-		SerialNumber:          serial,
-		NotBefore:             clk.Now(),
-		NotAfter:              clk.Now().AddDate(0, 0, 90),
-		KeyUsage:              x509.KeyUsageDigitalSignature,
-		ExtKeyUsage:           []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth, x509.ExtKeyUsageClientAuth},
-		BasicConstraintsValid: true,
-		IsCA: false,
-		IssuingCertificateURL: []string{"http://issuer" + testCertDomain},
-		CRLDistributionPoints: []string{"http://crls" + testCertDomain},
+	issueLeafCert := func(precert bool) (*x509.Certificate, error) {
+		tmpl := &x509.Certificate{
+			Subject: pkix.Name{
+				CommonName: domain,
+			},
+			DNSNames:              []string{domain},
+			SerialNumber:          serial,
+			NotBefore:             clk.Now(),
+			NotAfter:              clk.Now().AddDate(0, 0, 90),
+			KeyUsage:              x509.KeyUsageDigitalSignature,
+			ExtKeyUsage:           []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth, x509.ExtKeyUsageClientAuth},
+			BasicConstraintsValid: true,
+			IsCA: false,
+			IssuingCertificateURL: []string{"http://issuer" + testCertDomain},
+			CRLDistributionPoints: []string{"http://crls" + testCertDomain},
+		}
+		if precert {
+			tmpl.ExtraExtensions = []pkix.Extension{ctPoisonExtension}
+		}
+		return IssueCertificate(certKey.Public(), issuerKey, issuerCert, tmpl)
 	}
 
-	return IssueCertificate(certKey.Public(), issuerKey, issuerCert, template)
+	preCert, err := issueLeafCert(true)
+	if err != nil {
+		return CertificatePair{}, err
+	}
+	cert, err := issueLeafCert(false)
+	if err != nil {
+		return CertificatePair{}, err
+	}
+
+	return CertificatePair{
+		PreCert: preCert,
+		Cert:    cert,
+	}, nil
 }

--- a/pki/certs_test.go
+++ b/pki/certs_test.go
@@ -1,0 +1,164 @@
+package pki
+
+import (
+	"crypto"
+	"crypto/ecdsa"
+	"crypto/x509"
+	"encoding/hex"
+	"testing"
+
+	"github.com/jmhodges/clock"
+)
+
+func TestIssueCertificate(t *testing.T) {
+	testKey, _ := RandKey()
+	testCert := &x509.Certificate{}
+
+	testCases := []struct {
+		Name        string
+		SubjectKey  crypto.PublicKey
+		IssuerKey   *ecdsa.PrivateKey
+		IssuerCert  *x509.Certificate
+		Template    *x509.Certificate
+		ExpectedErr error
+	}{
+		{
+			Name:        "nil subjectkey",
+			ExpectedErr: nilSubjKeyErr,
+		},
+		{
+			Name:        "nil issuerkey",
+			SubjectKey:  testKey,
+			ExpectedErr: nilIssuerKeyErr,
+		},
+		{
+			Name:        "nil issuercert",
+			SubjectKey:  testKey,
+			IssuerKey:   testKey,
+			ExpectedErr: nilIssuerCertErr,
+		},
+		{
+			Name:        "nil template",
+			SubjectKey:  testKey,
+			IssuerKey:   testKey,
+			IssuerCert:  testCert,
+			ExpectedErr: nilTemplateErr,
+		},
+		{
+			Name:        "nil template",
+			SubjectKey:  testKey,
+			IssuerKey:   testKey,
+			IssuerCert:  testCert,
+			ExpectedErr: nilTemplateErr,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.Name, func(t *testing.T) {
+			_, err := IssueCertificate(tc.SubjectKey, tc.IssuerKey, tc.IssuerCert, tc.Template)
+			if err != tc.ExpectedErr {
+				t.Errorf("expected error %#v, got %#v\n", tc.ExpectedErr, err)
+			}
+		})
+	}
+}
+
+func TestIssueTestCertificate(t *testing.T) {
+	issuerKey, _ := RandKey()
+	issuerCert := &x509.Certificate{}
+	clk := clock.Default()
+
+	certPair, err := IssueTestCertificate(issuerKey, issuerCert, clk)
+	if err != nil {
+		t.Fatalf("unexpected error from IssueTestCertificate: %s", err.Error())
+	}
+
+	if certPair.PreCert == nil {
+		t.Fatalf("unexpected nil PreCert in CertPair returned from IssueTestCertificate")
+	}
+
+	if certPair.Cert == nil {
+		t.Fatalf("unexpected nil Cert in CertPair returned from IssueTestCertificate")
+	}
+
+	if certPair.PreCert.SerialNumber == nil {
+		t.Fatalf("unexpected nil SerialNumber in CertPair.PreCert")
+	}
+
+	if certPair.Cert.SerialNumber == nil {
+		t.Fatalf("unexpected nil SerialNumber in CertPair.Cert")
+	}
+
+	if certPair.PreCert.SerialNumber.Cmp(certPair.Cert.SerialNumber) != 0 {
+		t.Errorf("SerialNumbers of CertPair did not match")
+	}
+
+	expectedDomain := hex.EncodeToString(certPair.PreCert.SerialNumber.Bytes()[:5]) + testCertDomain
+	if certPair.PreCert.Subject.CommonName != expectedDomain {
+		t.Errorf("PreCert had wrong CommonName. Expected %q, had %q",
+			expectedDomain, certPair.PreCert.Subject.CommonName)
+	}
+	if certPair.PreCert.Subject.CommonName != certPair.Cert.Subject.CommonName {
+		t.Errorf("Cert had different CommonName from PreCert. Expected %q, had %q",
+			expectedDomain, certPair.Cert.Subject.CommonName)
+	}
+
+	if len(certPair.PreCert.DNSNames) != 1 || certPair.PreCert.DNSNames[0] != expectedDomain {
+		t.Errorf("PreCert had wrong DNSNames. Expected [%q], found %#v", expectedDomain, certPair.PreCert.DNSNames)
+	}
+	if len(certPair.Cert.DNSNames) != 1 || certPair.Cert.DNSNames[0] != expectedDomain {
+		t.Errorf("Cert had wrong DNSNames. Expected [%q], found %#v", expectedDomain, certPair.Cert.DNSNames)
+	}
+
+	if certPair.PreCert.IsCA {
+		t.Errorf("PreCert was unexpectedly a CA")
+	}
+	if certPair.Cert.IsCA {
+		t.Errorf("Cert was unexpectedly a CA")
+	}
+	if !certPair.PreCert.BasicConstraintsValid {
+		t.Errorf("PreCert was not BasicConstraintsValid")
+	}
+	if !certPair.Cert.BasicConstraintsValid {
+		t.Errorf("Cert was not BasicConstraintsValid")
+	}
+
+	if certPair.PreCert.KeyUsage != x509.KeyUsageDigitalSignature {
+		t.Errorf("PreCert had wrong KeyUsage. Expected %#v, found %#v", x509.KeyUsageDigitalSignature, certPair.PreCert.KeyUsage)
+	}
+	if certPair.Cert.KeyUsage != x509.KeyUsageDigitalSignature {
+		t.Errorf("Cert had wrong KeyUsage. Expected %#v, found %#v", x509.KeyUsageDigitalSignature, certPair.Cert.KeyUsage)
+	}
+
+	expectedIssuerURL := "http://issuer" + testCertDomain
+	if len(certPair.PreCert.IssuingCertificateURL) != 1 || certPair.PreCert.IssuingCertificateURL[0] != expectedIssuerURL {
+		t.Errorf("PreCert had wrong IssuingCertificateURL. Expected [%q], found %#v", expectedIssuerURL, certPair.PreCert.IssuingCertificateURL)
+	}
+	if len(certPair.Cert.IssuingCertificateURL) != 1 || certPair.Cert.IssuingCertificateURL[0] != expectedIssuerURL {
+		t.Errorf("Cert had wrong IssuingCertificateURL. Expected [%q], found %#v", expectedIssuerURL, certPair.Cert.IssuingCertificateURL)
+	}
+
+	expectedCRLURL := "http://crls" + testCertDomain
+	if len(certPair.PreCert.CRLDistributionPoints) != 1 || certPair.PreCert.CRLDistributionPoints[0] != expectedCRLURL {
+		t.Errorf("PreCert had wrong CRLDistributionPoints. Expected [%q], found %#v", expectedCRLURL, certPair.PreCert.CRLDistributionPoints)
+	}
+	if len(certPair.Cert.IssuingCertificateURL) != 1 || certPair.Cert.IssuingCertificateURL[0] != expectedIssuerURL {
+		t.Errorf("Cert had wrong CRLDistributionPoints. Expected [%q], found %#v", expectedCRLURL, certPair.Cert.CRLDistributionPoints)
+	}
+
+	findCTPoison := func(cert *x509.Certificate) bool {
+		foundPoison := false
+		for _, extension := range cert.Extensions {
+			if extension.Id.Equal(ctPoisonExtensionID) {
+				foundPoison = true
+			}
+		}
+		return foundPoison
+	}
+	if !findCTPoison(certPair.PreCert) {
+		t.Errorf("PreCert was missing expected CT Poision Extension ID")
+	}
+	if findCTPoison(certPair.Cert) {
+		t.Errorf("Cert had unexpected CT Poision Extension ID")
+	}
+}

--- a/pki/io_test.go
+++ b/pki/io_test.go
@@ -1,0 +1,111 @@
+package pki
+
+import (
+	"testing"
+
+	"github.com/letsencrypt/ct-woodpecker/test"
+)
+
+func TestLoadPrivateKey(t *testing.T) {
+	badB64 := `#$*$(`
+	badB64File := test.WriteTemp(t, badB64, "bad.b64")
+
+	// echo -n "lol keys" | base64
+	badKeyBytes := "bG9sIGtleXM="
+	badKeyFile := test.WriteTemp(t, badKeyBytes, "bad.key")
+
+	testCases := []struct {
+		Name        string
+		Path        string
+		ExpectError bool
+	}{
+		{
+			Name:        "Invalid file path",
+			Path:        "whatever.this.doesnt.even.exist.pem",
+			ExpectError: true,
+		},
+		{
+			Name:        "Invalid base64",
+			Path:        badB64File,
+			ExpectError: true,
+		},
+		{
+			Name:        "Invalid key",
+			Path:        badKeyFile,
+			ExpectError: true,
+		},
+		{
+			Name:        "Good key",
+			Path:        "../test/issuer.key",
+			ExpectError: false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.Name, func(t *testing.T) {
+			_, err := LoadPrivateKey(tc.Path)
+			if err != nil && !tc.ExpectError {
+				t.Errorf("Unexpected error: %s", err.Error())
+			} else if err == nil && tc.ExpectError {
+				t.Error("Expected error, got none")
+			}
+		})
+	}
+}
+
+func TestLoadCertificate(t *testing.T) {
+	noPEMFile := test.WriteTemp(t, "", "no.blocks.pem")
+
+	wrongPEM := `
+-----BEGIN GARBAGE-----
+bG9sIGtleXM=
+-----END GARBAGE-----
+`
+	wrongPEMFile := test.WriteTemp(t, wrongPEM, "wrong.type.pem")
+
+	extraBytes := wrongPEM + "!!bonus bytes!!"
+	extraBytesFile := test.WriteTemp(t, extraBytes, "extra.bytes.pem")
+
+	testCases := []struct {
+		Name        string
+		Path        string
+		ExpectError bool
+	}{
+		{
+			Name:        "Invalid file path",
+			Path:        "whatever.this.doesnt.even.exist.pem",
+			ExpectError: true,
+		},
+		{
+			Name:        "No PEM blocks",
+			Path:        noPEMFile,
+			ExpectError: true,
+		},
+		{
+			Name:        "Extra PEM bytes",
+			Path:        extraBytesFile,
+			ExpectError: true,
+		},
+		{
+			Name:        "Wrong PEM block type",
+			Path:        wrongPEMFile,
+			ExpectError: true,
+		},
+		{
+			Name:        "Valid PEM certificate",
+			Path:        "../test/issuer.pem",
+			ExpectError: false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.Name, func(t *testing.T) {
+			_, err := LoadCertificate(tc.Path)
+			if err != nil && !tc.ExpectError {
+				t.Errorf("Unexpected error: %s", err.Error())
+			} else if err == nil && tc.ExpectError {
+				t.Error("Expected error, got none")
+			}
+		})
+	}
+}

--- a/test/integration_test.go
+++ b/test/integration_test.go
@@ -302,7 +302,7 @@ func TestCertSubmissionSuccess(t *testing.T) {
 	// Run ct-woodpecker for the specified number of iterations using the above
 	// config
 	iterations := 2
-	padding := time.Millisecond * 80
+	padding := time.Millisecond * 90
 	duration := submitInterval*time.Duration(iterations) + padding
 	stdout, metricsData, err := woodpeckerRun(config, duration)
 	if err != nil {

--- a/test/io.go
+++ b/test/io.go
@@ -1,0 +1,23 @@
+package test
+
+import (
+	"io/ioutil"
+	"testing"
+)
+
+// WriteTemp writes the provided contents to a temp file with the provided
+// prefix and returns the path to the temp file. If there is an error,
+// `t.Fatalf` is called to end the test.
+func WriteTemp(t *testing.T, contents, prefix string) string {
+	tmpFile, err := ioutil.TempFile("", prefix)
+	if err != nil {
+		t.Fatalf("Unable to create tempfile: %s",
+			err.Error())
+	}
+	err = ioutil.WriteFile(tmpFile.Name(), []byte(contents), 0700)
+	if err != nil {
+		t.Fatalf("Unable to write tempfile contents: %s",
+			err.Error())
+	}
+	return tmpFile.Name()
+}

--- a/test/io.go
+++ b/test/io.go
@@ -1,6 +1,7 @@
 package test
 
 import (
+	"io"
 	"io/ioutil"
 	"testing"
 )
@@ -14,7 +15,7 @@ func WriteTemp(t *testing.T, contents, prefix string) string {
 		t.Fatalf("Unable to create tempfile: %s",
 			err.Error())
 	}
-	err = ioutil.WriteFile(tmpFile.Name(), []byte(contents), 0700)
+	_, err = io.WriteString(tmpFile, contents)
 	if err != nil {
 		t.Fatalf("Unable to write tempfile contents: %s",
 			err.Error())


### PR DESCRIPTION
This commit introduces support for periodically submitting precerts as
well as (or in place of) final certificates.

Some general cleanup, refactoring & test coverage improvement is
included as well. This includes fixing the flakyness on master (by
ensuring we wait for the cttestsrv instances to come up before
proceeding with the woodpecker run).

Resolves https://github.com/letsencrypt/ct-woodpecker/issues/21