### PR TITLE
Process STH fetching and (pre)cert submission async.

### DIFF
--- a/monitor/cert_submitter_test.go
+++ b/monitor/cert_submitter_test.go
@@ -45,6 +45,7 @@ func TestSubmitCertificate(t *testing.T) {
 	clk := clock.NewFake()
 	clk.Set(time.Now())
 	certInterval := time.Second
+	certTimeout := time.Millisecond * 5
 	logURI := "test"
 
 	// Create a logger backed by the safeBuffer. The log.Logger type is only safe
@@ -70,6 +71,7 @@ func TestSubmitCertificate(t *testing.T) {
 			LogKey: logKey,
 			SubmitOpts: &SubmitterOptions{
 				Interval:      certInterval,
+				Timeout:       certTimeout,
 				IssuerKey:     certIssuerKey,
 				IssuerCert:    certIssuer,
 				SubmitCert:    true,
@@ -116,6 +118,10 @@ func TestSubmitCertificate(t *testing.T) {
 		t.Run(tc.Name, func(t *testing.T) {
 			m.submitter.client = tc.MockClient
 			m.submitter.submitCertificates()
+
+			// Sleep for the submission timeout to allow the async submissions to
+			// complete
+			time.Sleep(certTimeout)
 
 			// There should be 1 latency observation for each test case
 			expectedLatencyObservations := i + 1

--- a/monitor/monitor.go
+++ b/monitor/monitor.go
@@ -131,6 +131,7 @@ func New(opts MonitorOptions, logger *log.Logger, clk clock.Clock) (*Monitor, er
 			client:           client,
 			logURI:           opts.LogURI,
 			sthFetchInterval: opts.FetchOpts.Interval,
+			sthTimeout:       opts.FetchOpts.Timeout,
 		}
 	}
 
@@ -142,6 +143,7 @@ func New(opts MonitorOptions, logger *log.Logger, clk clock.Clock) (*Monitor, er
 			client:             client,
 			logURI:             opts.LogURI,
 			certSubmitInterval: opts.SubmitOpts.Interval,
+			certSubmitTimeout:  opts.SubmitOpts.Timeout,
 			certIssuer:         opts.SubmitOpts.IssuerCert,
 			certIssuerKey:      opts.SubmitOpts.IssuerKey,
 			submitPreCert:      opts.SubmitOpts.SubmitPreCert,

--- a/monitor/monitor_test.go
+++ b/monitor/monitor_test.go
@@ -43,6 +43,7 @@ func TestNew(t *testing.T) {
 			LogKey: logKey,
 			FetchOpts: &FetcherOptions{
 				Interval: fetchDuration,
+				Timeout:  time.Second,
 			},
 		}, l, clk)
 	if err != nil {
@@ -97,6 +98,7 @@ func TestNew(t *testing.T) {
 			LogURI: logURI,
 			LogKey: logKey,
 			SubmitOpts: &SubmitterOptions{
+				Timeout:       time.Second,
 				Interval:      fetchDuration,
 				IssuerKey:     key,
 				IssuerCert:    cert,

--- a/monitor/sth_fetcher_test.go
+++ b/monitor/sth_fetcher_test.go
@@ -25,6 +25,7 @@ func TestObserveSTH(t *testing.T) {
 			LogKey: logKey,
 			FetchOpts: &FetcherOptions{
 				Interval: fetchDuration,
+				Timeout:  time.Second,
 			},
 		}, l, clk)
 	if err != nil {

--- a/test/config.json
+++ b/test/config.json
@@ -1,13 +1,20 @@
 {
   "metricsAddr": ":1971",
-  "sthFetchInterval": "120s",
-  "certSubmitInterval": "600s",
-  "certIssuer": "test/issuer.pem",
-  "certIssuerKey": "test/issuer.key",
+  "fetchConfig": {
+    "interval": "120s",
+    "timeout": "100s"
+  },
+  "submitConfig": {
+    "interval": "600s",
+    "timeout": "500s",
+    "certIssuerKeyPath": "test/issuer.key",
+    "certIssuerPath": "test/issuer.pem"
+  },
   "logs": [
     {
       "uri": "https://birch.ct.letsencrypt.org/2018",
       "key": "MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAElgyN7ptarCAX5krBwDwjhHM+b0xJjCKke+Dfr3GWSbLm3eO7muXRo8FDDdpdiRpnG4NJT0bdzq5YEer4C2eZ+g==",
+      "submitPreCert": true,
       "submitCert": true
     }
   ]

--- a/test/cttestsrv/server.go
+++ b/test/cttestsrv/server.go
@@ -209,9 +209,9 @@ func (is *IntegrationSrv) getSTHHandler(w http.ResponseWriter, r *http.Request) 
 		return
 	}
 
+	is.sleep()
 	// Track that an STH was fetched
 	atomic.AddInt64(&is.sthFetches, 1)
-	is.sleep()
 
 	is.RLock()
 	defer is.RUnlock()

--- a/woodpecker/woodpecker_test.go
+++ b/woodpecker/woodpecker_test.go
@@ -63,9 +63,11 @@ func TestConfigValid(t *testing.T) {
 	validConfig := Config{
 		FetchConfig: &STHFetchConfig{
 			Interval: "2s",
+			Timeout:  "1s",
 		},
 		SubmitConfig: &CertSubmitConfig{
 			Interval:          "60s",
+			Timeout:           "2s",
 			CertIssuerKeyPath: "⚷",
 			CertIssuerPath:    "foo",
 		},
@@ -108,6 +110,15 @@ func TestConfigValid(t *testing.T) {
 			},
 		},
 		{
+			Name: "Invalid STH Timeout",
+			Config: Config{
+				FetchConfig: &STHFetchConfig{
+					Interval: "2s",
+					Timeout:  "when the time is out, time out",
+				},
+			},
+		},
+		{
 			Name: "Log with submitCert, no SubmitConfig",
 			Config: Config{
 				Logs: validLogs,
@@ -132,10 +143,20 @@ func TestConfigValid(t *testing.T) {
 			},
 		},
 		{
+			Name: "Log with submitCert, invalid cert submit timeout",
+			Config: Config{
+				SubmitConfig: &CertSubmitConfig{
+					Interval: "2s",
+					Timeout:  "aaaa",
+				},
+			},
+		},
+		{
 			Name: "Log with submitCert, no cert issuer key path",
 			Config: Config{
 				SubmitConfig: &CertSubmitConfig{
 					Interval:          "2s",
+					Timeout:           "2s",
 					CertIssuerKeyPath: "",
 				},
 				Logs: validLogs,
@@ -146,6 +167,7 @@ func TestConfigValid(t *testing.T) {
 			Config: Config{
 				SubmitConfig: &CertSubmitConfig{
 					Interval:          "2s",
+					Timeout:           "2s",
 					CertIssuerKeyPath: "⚷",
 				},
 				Logs: validLogs,
@@ -156,6 +178,7 @@ func TestConfigValid(t *testing.T) {
 			Config: Config{
 				SubmitConfig: &CertSubmitConfig{
 					Interval:          "2s",
+					Timeout:           "2s",
 					CertIssuerKeyPath: "⚷",
 					CertIssuerPath:    "foo",
 				},
@@ -199,10 +222,12 @@ func TestConfigLoad(t *testing.T) {
 {
   "metricsAddr": ":1971",
   "fetchConfig": {
-    "interval": "120s"
+    "interval": "120s",
+    "timeout": "2s"
   },
   "submitConfig": {
     "interval": "360s",
+    "timeout": "2s",
     "certIssuerKeyPath": "test/issuer.key",
     "certIssuerPath": "test/issuer.pem"
   },
@@ -241,9 +266,11 @@ func TestConfigLoad(t *testing.T) {
 				MetricsAddr: ":1971",
 				FetchConfig: &STHFetchConfig{
 					Interval: "120s",
+					Timeout:  "2s",
 				},
 				SubmitConfig: &CertSubmitConfig{
 					Interval:          "360s",
+					Timeout:           "2s",
 					CertIssuerKeyPath: "test/issuer.key",
 					CertIssuerPath:    "test/issuer.pem",
 				},
@@ -303,6 +330,7 @@ func TestNew(t *testing.T) {
 	wp, err := New(Config{
 		FetchConfig: &STHFetchConfig{
 			Interval: "50s",
+			Timeout:  "1s",
 		},
 		Logs: logs,
 	}, l, clk)
@@ -331,6 +359,7 @@ func TestNew(t *testing.T) {
 	wp, err = New(Config{
 		SubmitConfig: &CertSubmitConfig{
 			Interval:          "20s",
+			Timeout:           "2s",
 			CertIssuerKeyPath: "../test/issuer.key",
 			CertIssuerPath:    "../test/issuer.pem",
 		},


### PR DESCRIPTION
Previously, each log's monitor's `STHFetcher` or
`CertSubmitter` would block on the STH fetch or cert submission
completing or timing out, sleep for the cycle duration, and then repeat.

The problem with this approach is that if a log has high latency the
monitoring schedule will gradually skew and we end up performing fewer
STH fetches/cert submissions than intended.

This commit updates the `certSubmitter` and `sthFetcher` to perform the
STH fetching and cert submission in separate goroutines. This ensures
that every cycle tries to perform its work even if the work ends up
lagging.

Along the way I exposed the timeout for both STH fetching and cert
submission back through the configuration layers to allow setting
a sensible timeout for both operations per-log.

Similarly, I updated the `test/config.json` example - it had fallen out
of date and would not load.

Resolves https://github.com/letsencrypt/ct-woodpecker/issues/14