### PR TITLE
Add systemd unit & makefile.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,44 @@
+BIN_DIR := $(GOPATH)/bin
+INSTALL_DIR := /usr/local/bin
+SERVICE_DIR := /etc/systemd/system
+
+WOODPECKER_USER := woodpecker
+WOODPECKER_HOME := /etc/ct-woodpecker
+WOODPECKER_CONFIG := $(WOODPECKER_HOME)/config.json
+WOODPECKER_ISSUER := $(WOODPECKER_HOME)/issuer.pem
+WOODPECKER_ISSUER_KEY := $(WOODPECKER_HOME)/issuer.key
+
+WOODPECKER_CMD := $(BIN_DIR)/ct-woodpecker
+WOODPECKER_DEFAULT_CONFIG := ./util/config.dist.json
+WOODPECKER_DEFAULT_ISSUER := ./test/issuer.pem
+WOODPECKER_DEFAULT_ISSUER_KEY := ./test/issuer.key
+WOODPECKER_SERVICE := ./util/ct-woodpecker.service
+
+GOCMD=go
+
+$(WOODPECKER_CMD):
+	$(GOCMD) get -u ./...
+	$(GOCMD) install ./...
+
+$(WOODPECKER_HOME):
+	mkdir $(WOODPECKER_HOME)
+
+$(WOODPECKER_ISSUER): $(WOODPECKER_HOME)
+	cp $(WOODPECKER_DEFAULT_ISSUER) $(WOODPECKER_ISSUER)
+
+$(WOODPECKER_ISSUER_KEY): $(WOODPECKER_HOME)
+	cp $(WOODPECKER_DEFAULT_ISSUER_KEY) $(WOODPECKER_ISSUER_KEY)
+	chmod 0640 $(WOODPECKER_ISSUER_KEY)
+
+$(WOODPECKER_CONFIG): $(WOODPECKER_HOME) $(WOODPECKER_ISSUER) $(WOODPECKER_ISSUER_KEY)
+	cp $(WOODPECKER_DEFAULT_CONFIG) $(WOODPECKER_CONFIG)
+
+.PHONY: install
+install: $(WOODPECKER_CMD) $(WOODPECKER_CONFIG)
+	cp $(WOODPECKER_CMD) $(INSTALL_DIR)
+	cp $(WOODPECKER_SERVICE) $(SERVICE_DIR)
+	chown -R $(WOODPECKER_USER):$(WOODPECKER_USER) $(WOODPECKER_HOME)
+	-adduser --disabled-password --no-create-home --shell=/bin/false --gecos "" $(WOODPECKER_USER)
+	systemctl daemon-reload
+	systemctl enable ct-woodpecker
+	systemctl start ct-woodpecker

--- a/util/config.dist.json
+++ b/util/config.dist.json
@@ -1,0 +1,21 @@
+{
+  "metricsAddr": ":1971",
+  "fetchConfig": {
+    "interval": "120s",
+    "timeout": "100s"
+  },
+  "submitConfig": {
+    "interval": "600s",
+    "timeout": "500s",
+    "certIssuerKeyPath": "/etc/ct-woodpecker/issuer.key",
+    "certIssuerPath": "/etc/ct-woodpecker/issuer.pem"
+  },
+  "logs": [
+    {
+      "uri": "https://birch.ct.letsencrypt.org/2018",
+      "key": "MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAElgyN7ptarCAX5krBwDwjhHM+b0xJjCKke+Dfr3GWSbLm3eO7muXRo8FDDdpdiRpnG4NJT0bdzq5YEer4C2eZ+g==",
+      "submitPreCert": true,
+      "submitCert": true
+    }
+  ]
+}

--- a/util/ct-woodpecker.service
+++ b/util/ct-woodpecker.service
@@ -1,0 +1,13 @@
+[Unit]
+Description=ct-woodpecker log monitor
+Wants=network-online.target
+After=network-online.target
+
+[Service]
+User=woodpecker
+Group=woodpecker
+Type=simple
+ExecStart=/usr/local/bin/ct-woodpecker --config /etc/ct-woodpecker/config.json
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
This commit adds a Makefile with an `install` PHONY target that will (if required):

1) Build `ct-woodpecker`
2) Create a `woodpecker` user with no home directory or shell access
3) Create a `/etc/ct-woodpecker` configuration dir
4) Populate `/etc/ct-woodpecker/config.json`,
   `/etc/ct-woodpecker/issuer.pem`, and `/etc/ct-woodpecker/issuer.key`
   with defaults
5) Install, enabled, and start a systemd unit for a simple
   `ct-woodpecker` service that runs `ct-woodpecker` as `woodpecker`
   with the `/etc/ct-woodpecker/config.json` configuration.

This is sufficient for a dead simple Linux-focused production install of
`ct-woodpecker`.

Resolves #15 