### PR TITLE
STH Fetcher: Verify consistency between STHs.

### DIFF
--- a/monitor/cert_submitter.go
+++ b/monitor/cert_submitter.go
@@ -117,14 +117,14 @@ type certSubmitter struct {
 func (c *certSubmitter) run() {
 	go func() {
 		for {
+			c.submitCertificates()
+			c.logger.Printf("Sleeping for %s before next certificate submission\n",
+				c.certSubmitInterval)
 			select {
 			case <-c.stopChannel:
 				return
 			case <-time.After(c.certSubmitInterval):
 			}
-			c.submitCertificates()
-			c.logger.Printf("Sleeping for %s before next certificate submission\n",
-				c.certSubmitInterval)
 		}
 	}()
 }

--- a/monitor/monitor.go
+++ b/monitor/monitor.go
@@ -187,3 +187,22 @@ func (m *Monitor) Stop() {
 		m.submitter.stop()
 	}
 }
+
+// wrapRspErr takes an errors as input and if it is a ctClient.RspError
+// instance it is returned in a wrapped form that prints the HTTP response
+// status and body in the error message. All other error types are passed
+// through unmodified.
+func wrapRspErr(err error) error {
+	if err == nil {
+		return nil
+	}
+
+	// If it is an RspError instance, wrap it
+	if rspErr, ok := err.(ctClient.RspError); ok {
+		return fmt.Errorf("%s HTTP Response Status: %d HTTP Response Body: %q",
+			rspErr.Err, rspErr.StatusCode, string(rspErr.Body))
+	}
+
+	// If it wasn't an RspError instance, return as-is
+	return err
+}

--- a/monitor/monitor.go
+++ b/monitor/monitor.go
@@ -28,6 +28,7 @@ type monitorCTClient interface {
 	GetSTH(context.Context) (*ct.SignedTreeHead, error)
 	AddChain(context.Context, []ct.ASN1Cert) (*ct.SignedCertificateTimestamp, error)
 	AddPreChain(context.Context, []ct.ASN1Cert) (*ct.SignedCertificateTimestamp, error)
+	GetSTHConsistency(context.Context, uint64, uint64) ([][]byte, error)
 }
 
 // MonitorOptions is a struct for holding monitor configuration options
@@ -124,16 +125,13 @@ func New(opts MonitorOptions, logger *log.Logger, clk clock.Clock) (*Monitor, er
 	}
 
 	if opts.FetchOpts != nil {
-		m.fetcher = &sthFetcher{
-			logger:           logger,
-			clk:              clk,
-			stats:            sthStats,
-			client:           client,
-			logURI:           opts.LogURI,
-			stopChannel:      make(chan bool),
-			sthFetchInterval: opts.FetchOpts.Interval,
-			sthTimeout:       opts.FetchOpts.Timeout,
-		}
+		m.fetcher = newSTHFetcher(
+			logger,
+			clk,
+			client,
+			opts.LogURI,
+			opts.FetchOpts.Interval,
+			opts.FetchOpts.Timeout)
 	}
 
 	if opts.SubmitOpts != nil {

--- a/monitor/monitor_test.go
+++ b/monitor/monitor_test.go
@@ -3,12 +3,14 @@ package monitor
 import (
 	"context"
 	"errors"
+	"fmt"
 	"log"
 	"os"
 	"testing"
 	"time"
 
 	ct "github.com/google/certificate-transparency-go"
+	ctClient "github.com/google/certificate-transparency-go/client"
 	"github.com/jmhodges/clock"
 	"github.com/letsencrypt/ct-woodpecker/pki"
 )
@@ -131,6 +133,56 @@ func TestNew(t *testing.T) {
 
 	if m.submitter.client == nil {
 		t.Errorf("Expected monitor submitter client to be non-nil")
+	}
+}
+
+func TestWrapRspErr(t *testing.T) {
+	normalErr := errors.New("just a normal error reporting for duty")
+
+	rspErr := ctClient.RspError{
+		Err:        normalErr,
+		StatusCode: 999,
+		Body:       []byte("This is the body of a ctClient.RspError"),
+	}
+
+	testCases := []struct {
+		Name        string
+		InputErr    error
+		ExpectedErr error
+	}{
+		{
+			Name:        "nil input err",
+			InputErr:    nil,
+			ExpectedErr: nil,
+		},
+		{
+			Name:        "non-RespError input err",
+			InputErr:    normalErr,
+			ExpectedErr: normalErr,
+		},
+		{
+			Name:     "rspError input err",
+			InputErr: rspErr,
+			ExpectedErr: fmt.Errorf("%s HTTP Response Status: %d HTTP Response Body: %q",
+				normalErr.Error(), rspErr.StatusCode, string(rspErr.Body)),
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.Name, func(t *testing.T) {
+			actualErr := wrapRspErr(tc.InputErr)
+			if tc.ExpectedErr == nil && actualErr != nil {
+				t.Fatalf("Expected err to be nil, was %#v", actualErr)
+			} else if tc.ExpectedErr != nil && actualErr == nil {
+				t.Fatalf("Expected err to be %#v, was nil", tc.ExpectedErr)
+			} else if tc.ExpectedErr != nil {
+				actual := actualErr.Error()
+				expected := tc.ExpectedErr.Error()
+				if actual != expected {
+					t.Errorf("Expected err %q got %q", expected, actual)
+				}
+			}
+		})
 	}
 }
 

--- a/monitor/monitor_test.go
+++ b/monitor/monitor_test.go
@@ -148,14 +148,22 @@ func (c errorClient) AddChain(_ context.Context, _ []ct.ASN1Cert) (*ct.SignedCer
 	return nil, errors.New("ct-log doesn't want any chains")
 }
 
+// AddPreChain mocked to always return an error
 func (c errorClient) AddPreChain(_ context.Context, _ []ct.ASN1Cert) (*ct.SignedCertificateTimestamp, error) {
 	return nil, errors.New("ct-log doesn't want any prechains")
 }
 
+// GetSTHConsistency mocked to always return an error
+func (c errorClient) GetSTHConsistency(_ context.Context, _ uint64, _ uint64) ([][]byte, error) {
+	return nil, errors.New("ct-log wants you to take its word that it is consistent")
+}
+
 // mockClient is a type implementing the monitorCTClient interface that always
-// returns a fixed mock STH from `GetSTH` and a mock SCT from `AddChain`
+// returns a mock STH from `GetSTH`, a mock SCT from `AddChain`, and a mock
+// proof from `GetSTHConsistency`
 type mockClient struct {
 	timestamp time.Time
+	proof     [][]byte
 }
 
 // GetSTH mocked to always return a fixed mock STH
@@ -180,4 +188,9 @@ func (c mockClient) AddPreChain(_ context.Context, _ []ct.ASN1Cert) (*ct.SignedC
 	return &ct.SignedCertificateTimestamp{
 		Timestamp: uint64(ts),
 	}, nil
+}
+
+// GetSTHConsistency mocked to always return a fixed consistency proof
+func (c mockClient) GetSTHConsistency(_ context.Context, _ uint64, _ uint64) ([][]byte, error) {
+	return c.proof, nil
 }

--- a/monitor/sth_fetcher.go
+++ b/monitor/sth_fetcher.go
@@ -151,7 +151,7 @@ func (f *sthFetcher) logErrorf(format string, args ...interface{}) {
 // logf formats a message to write to the sthFetcher's logger prefixed to
 // identify the source as an sth-fetcher for a specific logURI
 func (f *sthFetcher) logf(format string, args ...interface{}) {
-	line := fmt.Sprintf(format, args)
+	line := fmt.Sprintf(format, args...)
 	f.logger.Print("sth-fetcher", f.logURI, ":", line)
 }
 
@@ -203,9 +203,7 @@ func (f *sthFetcher) observeSTH() {
 	f.stats.sthLatency.With(labels).Observe(elapsed.Seconds())
 
 	if err != nil {
-		// Include both %q and %#v so that `client.RespError` instances are logged
-		// with the full error information and not just the message
-		f.logErrorf("failed to fetch STH: %q : %#v", err.Error(), err)
+		f.logErrorf("failed to fetch STH: %s", wrapRspErr(err))
 		f.stats.sthFailures.With(labels).Inc()
 		return
 	}
@@ -298,8 +296,8 @@ func (f *sthFetcher) verifySTHConsistency(firstSTH, secondSTH *ct.SignedTreeHead
 	if err != nil {
 		errorLabels := prometheus.Labels{"uri": f.logURI, "type": "failed-to-get-proof"}
 		f.stats.sthInconsistencies.With(errorLabels).Inc()
-		f.logErrorf("failed to get consistency proof %s: %q : %#v - firstSTH: %#v secondSTH: %#v",
-			proofDescription, err.Error(), err, firstSTH, secondSTH)
+		f.logErrorf("failed to get consistency proof %s : %s : firstSTH: %#v secondSTH: %#v",
+			proofDescription, wrapRspErr(err), firstSTH, secondSTH)
 		return
 	}
 
@@ -313,8 +311,8 @@ func (f *sthFetcher) verifySTHConsistency(firstSTH, secondSTH *ct.SignedTreeHead
 		consistencyProof); err != nil {
 		errorLabels := prometheus.Labels{"uri": f.logURI, "type": "failed-to-verify-proof"}
 		f.stats.sthInconsistencies.With(errorLabels).Inc()
-		f.logErrorf("failed to verify consistency proof %s: %q : %#v",
-			proofDescription, err.Error(), err)
+		f.logErrorf("failed to verify consistency proof %s : %s",
+			proofDescription, err)
 		return
 	}
 

--- a/monitor/sth_fetcher.go
+++ b/monitor/sth_fetcher.go
@@ -126,13 +126,14 @@ func newSTHFetcher(
 	return &sthFetcher{
 		logger:           logger,
 		clk:              clk,
-		stats:            sthStats,
 		client:           client,
 		logURI:           logURI,
-		stopChannel:      make(chan bool),
 		sthFetchInterval: sthFetchInterval,
 		sthTimeout:       sthTimeout,
-		verifier:         merkle.NewLogVerifier(rfc6962.DefaultHasher),
+
+		stats:       sthStats,
+		stopChannel: make(chan bool),
+		verifier:    merkle.NewLogVerifier(rfc6962.DefaultHasher),
 	}
 }
 

--- a/monitor/sth_fetcher.go
+++ b/monitor/sth_fetcher.go
@@ -215,7 +215,7 @@ func (f *sthFetcher) observeSTH() {
 	sthAge := f.clk.Since(ts)
 	f.stats.sthAge.With(labels).Set(sthAge.Seconds())
 
-	f.logf("STH verified. Timestamp: %s Age: %s TreeSize: %d Root Hash: %x",
+	f.logf("STH signature verified. Timestamp: %s Age: %s TreeSize: %d Root Hash: %x",
 		ts, sthAge, newSTH.TreeSize, newSTH.SHA256RootHash)
 
 	f.prevSTHMu.Lock()

--- a/monitor/sth_fetcher.go
+++ b/monitor/sth_fetcher.go
@@ -106,8 +106,8 @@ type sthFetcher struct {
 	// prevSTH is the last STH that was fetched from the log
 	prevSTH *ct.SignedTreeHead
 
-	// sthLock is a Mutex for controlling updates to prevSTH
-	sthLock sync.Mutex
+	// prevSTHMu is a Mutex for controlling updates to prevSTH
+	prevSTHMu sync.Mutex
 
 	// verifier is used by verifySTHConsistency to prove consistency between two
 	// STHs
@@ -215,8 +215,8 @@ func (f *sthFetcher) observeSTH() {
 	f.logf("STH verified. Timestamp: %s Age: %s TreeSize: %d Root Hash: %x",
 		ts, sthAge, newSTH.TreeSize, newSTH.SHA256RootHash)
 
-	f.sthLock.Lock()
-	defer f.sthLock.Unlock()
+	f.prevSTHMu.Lock()
+	defer f.prevSTHMu.Unlock()
 
 	if f.prevSTH != nil {
 		go f.verifySTHConsistency(f.prevSTH, newSTH)

--- a/monitor/sth_fetcher.go
+++ b/monitor/sth_fetcher.go
@@ -202,6 +202,8 @@ func (f *sthFetcher) observeSTH() {
 	f.stats.sthLatency.With(labels).Observe(elapsed.Seconds())
 
 	if err != nil {
+		// Include both %q and %#v so that `client.RespError` instances are logged
+		// with the full error information and not just the message
 		f.logErrorf("failed to fetch STH: %q : %#v", err.Error(), err)
 		f.stats.sthFailures.With(labels).Inc()
 		return

--- a/monitor/sth_fetcher.go
+++ b/monitor/sth_fetcher.go
@@ -298,8 +298,8 @@ func (f *sthFetcher) verifySTHConsistency(firstSTH, secondSTH *ct.SignedTreeHead
 	if err != nil {
 		errorLabels := prometheus.Labels{"uri": f.logURI, "type": "failed-to-get-proof"}
 		f.stats.sthInconsistencies.With(errorLabels).Inc()
-		f.logErrorf("failed to get consistency proof %s: %q : %#v",
-			proofDescription, err.Error(), err)
+		f.logErrorf("failed to get consistency proof %s: %q : %#v - firstSTH: %#v secondSTH: %#v",
+			proofDescription, err.Error(), err, firstSTH, secondSTH)
 		return
 	}
 

--- a/monitor/sth_fetcher.go
+++ b/monitor/sth_fetcher.go
@@ -1,11 +1,16 @@
 package monitor
 
 import (
+	"bytes"
 	"context"
 	"errors"
+	"fmt"
 	"log"
 	"time"
 
+	ct "github.com/google/certificate-transparency-go"
+	"github.com/google/trillian/merkle"
+	"github.com/google/trillian/merkle/rfc6962"
 	"github.com/jmhodges/clock"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
@@ -14,10 +19,12 @@ import (
 // sthFetchStats is a type to hold the prometheus metrics used by
 // a sthFetcher
 type sthFetchStats struct {
-	sthTimestamp *prometheus.GaugeVec
-	sthAge       *prometheus.GaugeVec
-	sthFailures  *prometheus.CounterVec
-	sthLatency   *prometheus.HistogramVec
+	sthTimestamp       *prometheus.GaugeVec
+	sthAge             *prometheus.GaugeVec
+	sthFailures        *prometheus.CounterVec
+	sthLatency         *prometheus.HistogramVec
+	sthProofLatency    *prometheus.HistogramVec
+	sthInconsistencies *prometheus.CounterVec
 }
 
 // sthStats is a sthFetchStats instance with promauto registered
@@ -40,6 +47,15 @@ var sthStats *sthFetchStats = &sthFetchStats{
 		Help:    "Latency observing CT log signed tree head (STH)",
 		Buckets: internetFacingBuckets,
 	}, []string{"uri"}),
+	sthProofLatency: promauto.NewHistogramVec(prometheus.HistogramOpts{
+		Name:    "sth_proof_latency",
+		Help:    "Latency requesting CT signed tree head (STH) consistency proof",
+		Buckets: internetFacingBuckets,
+	}, []string{"uri"}),
+	sthInconsistencies: promauto.NewCounterVec(prometheus.CounterOpts{
+		Name: "sth_inconsistencies",
+		Help: "Count of times two CT log signed tree heads (STHs) could not be proved consistent",
+	}, []string{"uri", "type"}),
 }
 
 // FetcherOptions is a struct holding options for STH fetching.
@@ -62,6 +78,13 @@ func (o FetcherOptions) Valid() error {
 	return nil
 }
 
+// sthFetcherVerifier is an interface that specifies the merkle.LogVerifier
+// functions that the sthFetcher uses. This interface allows for easy
+// shimming of client methods with mock implementations for unit testing.
+type sthFetcherVerifier interface {
+	VerifyConsistencyProof(int64, int64, []byte, []byte, [][]byte) error
+}
+
 // sthFetcher is a type for periodically fetching a log's STH and publishing
 // metrics about it.
 type sthFetcher struct {
@@ -75,8 +98,63 @@ type sthFetcher struct {
 
 	// How long to sleep between fetching the log's current STH
 	sthFetchInterval time.Duration
-	// How long to wait before giving up on an STH fetch
+	// How long to wait before giving up on an STH fetch or an STH consistency
+	// proof.
 	sthTimeout time.Duration
+
+	// prevSTH is the last STH that was fetched from the log
+	prevSTH *ct.SignedTreeHead
+
+	// verifier is used by verifySTHConsistency to prove consistency between two
+	// STHs
+	verifier sthFetcherVerifier
+}
+
+// newSTHFetcher returns an sthFetcher instance populated based on the provided
+// arguments
+func newSTHFetcher(
+	logger *log.Logger,
+	clk clock.Clock,
+	client monitorCTClient,
+	logURI string,
+	sthFetchInterval time.Duration,
+	sthTimeout time.Duration) *sthFetcher {
+	return &sthFetcher{
+		logger:           logger,
+		clk:              clk,
+		stats:            sthStats,
+		client:           client,
+		logURI:           logURI,
+		stopChannel:      make(chan bool),
+		sthFetchInterval: sthFetchInterval,
+		sthTimeout:       sthTimeout,
+		verifier:         merkle.NewLogVerifier(rfc6962.DefaultHasher),
+	}
+}
+
+// logErrorf formats a message to the sthFetcher's logger prefixed to identify
+// that an error occurred, that it was an sth-fetcher, and the logURI the error
+// affects
+func (f *sthFetcher) logErrorf(format string, args ...interface{}) {
+	// TODO(@cpu): We should be using os.Stderr here but doing so will mean
+	// changing integration tests. See
+	// https://github.com/letsencrypt/ct-woodpecker/issues/36
+	f.logger.Printf(
+		fmt.Sprintf("[ERROR] sth-fetcher %s : %s\n", f.logURI, format),
+		args...)
+}
+
+// logf formats a message to write to the sthFetcher's logger prefixed to
+// identify the source as an sth-fetcher for a specific logURI
+func (f *sthFetcher) logf(format string, args ...interface{}) {
+	f.logger.Printf(fmt.Sprintf("sth-fetcher %s : %s\n", f.logURI, format), args...)
+}
+
+// log writes a message to the sthFetcher's logger prefixed to identify the
+// source as an sth-fetcher for a specific logURI. For format string usage see
+// logf.
+func (f *sthFetcher) log(msg string) {
+	f.logger.Printf("sth-fetcher %s : %s\n", f.logURI, msg)
 }
 
 // Run starts the log STH fetching process by creating a goroutine that will loop
@@ -84,19 +162,19 @@ type sthFetcher struct {
 func (f *sthFetcher) run() {
 	go func() {
 		for {
+			go f.observeSTH()
+			f.logf("Sleeping for %s before next STH check\n", f.sthFetchInterval)
 			select {
 			case <-f.stopChannel:
 				return
 			case <-time.After(f.sthFetchInterval):
 			}
-			go f.observeSTH()
-			f.logger.Printf("Sleeping for %s before next STH check\n", f.sthFetchInterval)
 		}
 	}()
 }
 
 func (f *sthFetcher) stop() {
-	f.logger.Printf("Stopping %s sthFetcher", f.logURI)
+	f.log("Stopping")
 	f.stopChannel <- true
 }
 
@@ -105,28 +183,130 @@ func (f *sthFetcher) stop() {
 // since the STH's timestamp is published to the `sth_age` metric. If an error
 // occurs the `sth_failures` metric will be incremented. If the operation
 // succeeds then the `sth_timestamp` gauge will be updated to the returned STH's
-// timestamp.
+// timestamp. The newly observerd STH will be stored as `f.prevSTH`. If
+// `f.prevSTH` is not nil, then `observeSTH` will asynchronously validate
+// consistency between `f.prevSTH` and the newly observed STH.
 func (f *sthFetcher) observeSTH() {
 	labels := prometheus.Labels{"uri": f.logURI}
-	f.logger.Printf("Fetching STH for %q\n", f.logURI)
+	f.log("Fetching STH")
 
 	start := f.clk.Now()
 	ctx, cancel := context.WithTimeout(context.Background(), f.sthTimeout)
 	defer cancel()
-	sth, err := f.client.GetSTH(ctx)
+	newSTH, err := f.client.GetSTH(ctx)
 	elapsed := f.clk.Since(start)
 	f.stats.sthLatency.With(labels).Observe(elapsed.Seconds())
 
 	if err != nil {
-		f.logger.Printf("!! Error fetching STH: %s\n", err.Error())
+		f.logErrorf("failed to fetch STH: %q : %#v", err.Error(), err)
 		f.stats.sthFailures.With(labels).Inc()
 		return
 	}
 
-	f.stats.sthTimestamp.With(labels).Set(float64(sth.Timestamp))
-	ts := time.Unix(0, int64(sth.Timestamp)*int64(time.Millisecond))
+	f.stats.sthTimestamp.With(labels).Set(float64(newSTH.Timestamp))
+	ts := time.Unix(0, int64(newSTH.Timestamp)*int64(time.Millisecond))
 	sthAge := f.clk.Since(ts)
 	f.stats.sthAge.With(labels).Set(sthAge.Seconds())
 
-	f.logger.Printf("STH for %q verified. Timestamp: %s Age: %s\n", f.logURI, ts, sthAge)
+	f.logf("STH verified. Timestamp: %s Age: %s TreeSize: %d Root Hash: %x",
+		ts, sthAge, newSTH.TreeSize, newSTH.SHA256RootHash)
+
+	if f.prevSTH != nil {
+		go f.verifySTHConsistency(f.prevSTH, newSTH)
+	}
+	f.prevSTH = newSTH
+}
+
+// verifySTHConsistency fetches and validates a consistency proof between
+// firstSTH and secondSTH. If the two STHs don't verify then the
+// `sth_inconsistencies` prometheus counter is incremented with a label
+// indicating the category of inconsistency and an error is logged with
+// `logErrorf`. Presently there are three possible categories of STH consistency
+// failure:
+// 1. "equal-treesize-inequal-hash" - the two STHs are the same tree size but
+//    have different root hashes.
+// 2. "failed-to-get-proof" - the monitor encountered an error getting
+//    a consistency proof between the two STHs from the log.
+// 3. "failed-to-verify-proof" - the monitor returned a proof of consistency
+//    between the two STHs that did not verify.
+// When the monitor fetches a consistency proof from the log it publishes the
+// latency of the operation to the `sth_proof_latency` prometheus histogram.
+func (f *sthFetcher) verifySTHConsistency(firstSTH, secondSTH *ct.SignedTreeHead) {
+	if firstSTH == nil || secondSTH == nil {
+		f.logErrorf("firstSTH or secondSTH was nil")
+		return
+	}
+
+	firstTreeSize := firstSTH.TreeSize
+	firstHash := firstSTH.SHA256RootHash[:]
+
+	secondTreeSize := secondSTH.TreeSize
+	secondHash := secondSTH.SHA256RootHash[:]
+
+	// If the two STH's have equal tree sizes then we expect the SHA256RootHash to
+	// match. If it doesn't match there is no need to check the consistency proofs
+	// because the log is definitely inconsistent. In this case publish an
+	// increment to the `sthInconsistencies` stat
+	if firstTreeSize == secondTreeSize && !bytes.Equal(firstHash, secondHash) {
+		errorLabels := prometheus.Labels{"uri": f.logURI, "type": "equal-treesize-inequal-hash"}
+		f.stats.sthInconsistencies.With(errorLabels).Inc()
+		f.logErrorf("first STH and second STH have same tree size (%d) "+
+			"but different tree hashes. first.SHA256RootHash: %x "+
+			"second.SHA256RootHash: %x",
+			firstTreeSize,
+			firstHash,
+			secondHash)
+		return
+	} else if firstTreeSize == secondTreeSize {
+		// If the two STH's have equal tree sizes and equal SHA256RootHashes there
+		// isn't anything to do. We need STH's from two different tree states to
+		// verify consistency
+		f.logf("first STH and second STH have same SHA256RootHash (%x) "+
+			"and tree size (%d). No consistency proof required",
+			firstHash, firstTreeSize)
+		return
+	}
+
+	// proofDescription is used in log messages to describe the proof being
+	// fetched/verified
+	proofDescription := fmt.Sprintf(
+		"from treesize %d (hash %x) to treesize %d (hash %x)",
+		firstTreeSize, firstHash, secondTreeSize, secondHash)
+
+	// Fetch the consistency proof between the two tree sizes from the log.
+	// Observe the latency of this operation using the `sthProofLatency` stat. If
+	// the operation fails, consider it an inconsistency and publish an increment
+	// to the `sthInconsistencies` stat.
+	ctx, cancel := context.WithTimeout(context.Background(), f.sthTimeout)
+	defer cancel()
+	start := f.clk.Now()
+	f.logf("Getting consistency proof %s", proofDescription)
+	consistencyProof, err := f.client.GetSTHConsistency(ctx, firstTreeSize, secondTreeSize)
+	elapsed := f.clk.Since(start)
+	labels := prometheus.Labels{"uri": f.logURI}
+	f.stats.sthProofLatency.With(labels).Observe(elapsed.Seconds())
+	if err != nil {
+		errorLabels := prometheus.Labels{"uri": f.logURI, "type": "failed-to-get-proof"}
+		f.stats.sthInconsistencies.With(errorLabels).Inc()
+		f.logErrorf("failed to get consistency proof %s: %q : %#v",
+			proofDescription, err.Error(), err)
+		return
+	}
+
+	// Verify the consistency proof. If the proof fails to verify then publish an
+	// increment to the `sthInconsistencies` stat
+	if err := f.verifier.VerifyConsistencyProof(
+		int64(firstTreeSize),
+		int64(secondTreeSize),
+		firstHash,
+		secondHash,
+		consistencyProof); err != nil {
+		errorLabels := prometheus.Labels{"uri": f.logURI, "type": "failed-to-verify-proof"}
+		f.stats.sthInconsistencies.With(errorLabels).Inc()
+		f.logErrorf("failed to verify consistency proof %s: %q : %#v",
+			proofDescription, err.Error(), err)
+		return
+	}
+
+	f.logf("verified consistency proof %s", proofDescription)
 }

--- a/monitor/sth_fetcher.go
+++ b/monitor/sth_fetcher.go
@@ -144,9 +144,8 @@ func (f *sthFetcher) logErrorf(format string, args ...interface{}) {
 	// TODO(@cpu): We should be using os.Stderr here but doing so will mean
 	// changing integration tests. See
 	// https://github.com/letsencrypt/ct-woodpecker/issues/36
-	f.logger.Printf(
-		fmt.Sprintf("[ERROR] sth-fetcher %s : %s\n", f.logURI, format),
-		args...)
+	line := fmt.Sprintf(format, args...)
+	f.logger.Print("[ERROR]", "sth-fetcher", f.logURI, ":", line)
 }
 
 // logf formats a message to write to the sthFetcher's logger prefixed to

--- a/monitor/sth_fetcher.go
+++ b/monitor/sth_fetcher.go
@@ -151,7 +151,8 @@ func (f *sthFetcher) logErrorf(format string, args ...interface{}) {
 // logf formats a message to write to the sthFetcher's logger prefixed to
 // identify the source as an sth-fetcher for a specific logURI
 func (f *sthFetcher) logf(format string, args ...interface{}) {
-	f.logger.Printf(fmt.Sprintf("sth-fetcher %s : %s\n", f.logURI, format), args...)
+	line := fmt.Sprintf(format, args)
+	f.logger.Print("sth-fetcher", f.logURI, ":", line)
 }
 
 // log writes a message to the sthFetcher's logger prefixed to identify the

--- a/monitor/sth_fetcher_test.go
+++ b/monitor/sth_fetcher_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 	"time"
 
+	ct "github.com/google/certificate-transparency-go"
 	"github.com/jmhodges/clock"
 	"github.com/letsencrypt/ct-woodpecker/test"
 	"github.com/prometheus/client_golang/prometheus"
@@ -99,5 +100,139 @@ func TestObserveSTH(t *testing.T) {
 	}
 	if tsValue != expectedTSValue {
 		t.Errorf("Expected m.fetcher.stats.sthTimestamp to be %d, was %d", expectedTSValue, tsValue)
+	}
+
+	// The previous STH should be set correctly
+	if m.fetcher.prevSTH == nil {
+		t.Fatalf("Expected non-nil m.fetcher.prevSTH, was nil")
+	}
+	actualTS := int64(m.fetcher.prevSTH.Timestamp)
+	expectedTS := sthTimestamp.UnixNano() / int64(time.Millisecond)
+	if actualTS != expectedTS {
+		t.Errorf("Expected m.fetcher.prevSTH.Timestamp to be %d was %d\n",
+			expectedTS, actualTS)
+	}
+}
+
+// mockVerifier is a mock implementing the sthFetcherVerifier interface. It
+// provides a `VerifyConsistencyProof` function that verifies any arguments as
+// valid.
+type mockVerifier struct{}
+
+func (v mockVerifier) VerifyConsistencyProof(_, _ int64, _, _ []byte, _ [][]byte) error {
+	// mockVerifier does not actual verification and returns nil to indicate
+	// everything is a-OK
+	return nil
+}
+
+func TestVerifySTHConsistency(t *testing.T) {
+	l := log.New(os.Stdout, "", log.LstdFlags)
+	clk := clock.NewFake()
+	clk.Set(time.Now())
+	fetchInterval := time.Second
+	logURI := "test"
+
+	// Create a fetcher backed by an errorClient
+	f := newSTHFetcher(l, clk, errorClient{}, logURI, fetchInterval, time.Second)
+
+	first := &ct.SignedTreeHead{
+		TreeSize:       1337,
+		SHA256RootHash: ct.SHA256Hash{0x1D, 0xEA, 0x1},
+	}
+	second := &ct.SignedTreeHead{
+		TreeSize:       first.TreeSize,
+		SHA256RootHash: ct.SHA256Hash{0xD1, 0x5B, 0xE1, 0x1E, 0xF},
+	}
+
+	// Verifying the consistency between two STHs that have the same treesize and
+	// different hashes should increment the inconsistencies stat with the correct
+	// type label and not increment the latency stat
+	f.verifySTHConsistency(first, second)
+	inequalHashLabels := prometheus.Labels{"uri": logURI, "type": "equal-treesize-inequal-hash"}
+	failureMetric := test.MustCountCounterVecWithLabels(f.stats.sthInconsistencies, inequalHashLabels)
+	expectedFailures := 1
+	if failureMetric != expectedFailures {
+		t.Errorf("Expected m.fetcher.stats.sthInconsistencies to be %d, was %d",
+			expectedFailures, failureMetric)
+	}
+	latencyLabels := prometheus.Labels{"uri": logURI}
+	latencySamples := test.MustCountHistogramSamplesWithLabels(f.stats.sthProofLatency, latencyLabels)
+	expectedLatencySamples := 0
+	if latencySamples != expectedLatencySamples {
+		t.Errorf("Expected %d m.fetcher.stats.sthProofLatency samples, found %d", expectedLatencySamples, latencySamples)
+	}
+
+	// Change the second STH's hash to match the first's
+	second.SHA256RootHash = first.SHA256RootHash
+
+	// Verifying the consistency between two STHs that have the same treesize and
+	// the same hashes should not increment the inconsistencies stat or the
+	// number of latency observations
+	f.verifySTHConsistency(first, second)
+	failureMetric = test.MustCountCounterVecWithLabels(f.stats.sthInconsistencies, inequalHashLabels)
+	if failureMetric != expectedFailures {
+		t.Errorf("Expected m.fetcher.stats.sthInconsistencies to be %d, was %d",
+			expectedFailures, failureMetric)
+	}
+	latencySamples = test.MustCountHistogramSamplesWithLabels(f.stats.sthProofLatency, latencyLabels)
+	if latencySamples != expectedLatencySamples {
+		t.Errorf("Expected %d m.fetcher.stats.sthProofLatency samples, found %d", expectedLatencySamples, latencySamples)
+	}
+
+	// Change the second STH's tree size and hash so there is a reason to fetch a consistency proof
+	second.TreeSize = 7331
+	second.SHA256RootHash = ct.SHA256Hash{0xD1, 0x5B, 0xE1, 0x1E, 0xF}
+
+	// Verifying the consistency between two STHs with the errorClient should
+	// increment the inconsistencies stat and the number of latency observations
+	f.verifySTHConsistency(first, second)
+	proofGetFailureLabels := prometheus.Labels{"uri": logURI, "type": "failed-to-get-proof"}
+	failureMetric = test.MustCountCounterVecWithLabels(f.stats.sthInconsistencies, proofGetFailureLabels)
+	expectedFailures = 1
+	if failureMetric != expectedFailures {
+		t.Errorf("Expected m.fetcher.stats.sthInconsistencies to be %d, was %d",
+			expectedFailures, failureMetric)
+	}
+	latencySamples = test.MustCountHistogramSamplesWithLabels(f.stats.sthProofLatency, latencyLabels)
+	expectedLatencySamples = 1
+	if latencySamples != expectedLatencySamples {
+		t.Errorf("Expected %d m.fetcher.stats.sthProofLatency samples, found %d", expectedLatencySamples, latencySamples)
+	}
+
+	// Replace the fetcher client with one that returns a bogus proof when asked
+	f.client = mockClient{proof: [][]byte{{0xFA, 0xCA, 0xDE}}}
+
+	// Verifying the consistency between two STHs with the mockClient should
+	// increment the inconsistencies stat and the number of latency observations
+	f.verifySTHConsistency(first, second)
+	badProofLabels := prometheus.Labels{"uri": logURI, "type": "failed-to-verify-proof"}
+	failureMetric = test.MustCountCounterVecWithLabels(f.stats.sthInconsistencies, badProofLabels)
+	expectedFailures = 1
+	if failureMetric != expectedFailures {
+		t.Errorf("Expected m.fetcher.stats.sthInconsistencies to be %d, was %d",
+			expectedFailures, failureMetric)
+	}
+	latencySamples = test.MustCountHistogramSamplesWithLabels(f.stats.sthProofLatency, latencyLabels)
+	expectedLatencySamples++
+	if latencySamples != expectedLatencySamples {
+		t.Errorf("Expected %d m.fetcher.stats.sthProofLatency samples, found %d", expectedLatencySamples, latencySamples)
+	}
+
+	// Replace the fetcher's verifier with one that assumes any proof is valid
+	f.verifier = mockVerifier{}
+
+	// Verifying the consistency between two STHs using the mock verifier should
+	// not increment the inconsistencies stat but it should increment the number
+	// of latency observations
+	f.verifySTHConsistency(first, second)
+	failureMetric = test.MustCountCounterVecWithLabels(f.stats.sthInconsistencies, badProofLabels)
+	if failureMetric != expectedFailures {
+		t.Errorf("Expected m.fetcher.stats.sthInconsistencies to be %d, was %d",
+			expectedFailures, failureMetric)
+	}
+	latencySamples = test.MustCountHistogramSamplesWithLabels(f.stats.sthProofLatency, latencyLabels)
+	expectedLatencySamples++
+	if latencySamples != expectedLatencySamples {
+		t.Errorf("Expected %d m.fetcher.stats.sthProofLatency samples, found %d", expectedLatencySamples, latencySamples)
 	}
 }

--- a/test/integration_test.go
+++ b/test/integration_test.go
@@ -424,7 +424,7 @@ func TestCoordinatedSTHOmission(t *testing.T) {
 
 	slowCount, fastCount := 0, 0
 	for _, srv := range testServers {
-		expectedFetchLine := fmt.Sprintf(`Fetching STH for "http://localhost%s"`,
+		expectedFetchLine := fmt.Sprintf(`sth-fetcher http://localhost%s : Fetching STH`,
 			srv.Addr)
 		fetchLinesCount := strings.Count(stdout, expectedFetchLine)
 

--- a/test/metrics.go
+++ b/test/metrics.go
@@ -26,6 +26,14 @@ func CountCounterVecWithLabels(counterVec *prometheus.CounterVec, labels prometh
 	return int(iom.Counter.GetValue()), nil
 }
 
+func MustCountCounterVecWithLabels(counterVec *prometheus.CounterVec, labels prometheus.Labels) int {
+	count, err := CountCounterVecWithLabels(counterVec, labels)
+	if err != nil {
+		panic(fmt.Sprintf("failed to get countervec counter: %#v", err))
+	}
+	return count
+}
+
 // GaugeValueWithLabels returns the current value with the provided labels from the
 // the GaugeVec argument, or an error if there was a problem collecting the value.
 func GaugeValueWithLabels(vecGauge *prometheus.GaugeVec, labels prometheus.Labels) (int, error) {
@@ -73,4 +81,12 @@ func CountHistogramSamplesWithLabels(histVec *prometheus.HistogramVec, labels pr
 	var iom io_prometheus_client.Metric
 	_ = m.Write(&iom)
 	return int(iom.Histogram.GetSampleCount()), nil
+}
+
+func MustCountHistogramSamplesWithLabels(histVec *prometheus.HistogramVec, labels prometheus.Labels) int {
+	count, err := CountHistogramSamplesWithLabels(histVec, labels)
+	if err != nil {
+		panic(fmt.Sprintf("failed to get histogram samples: %#v", err))
+	}
+	return count
 }


### PR DESCRIPTION
_Note to reviewers: This branch doesn't have an integration test.
 I think it should but wanted to get some :mag: input before I was
 OOO for Canada day_

After fetching more than one STH the monitor will now verify the
consistency between the current STH and the previously observed STH.

Errors are tracked in the Prometheus `sth_inconsistencies` counter vec
sliced by the log URI and the type of inconsistency (bad STHs, failure
to get a consistency proof, failure to validate the consistency proof).

The latency of fetching a STH consistency proof is tracked in the
Prometheus `sth_proof_latency` histogram.

Resolves https://github.com/letsencrypt/ct-woodpecker/issues/4
