### PR TITLE
woodpecker: wire up certificate inclusion checker.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,30 @@
+# Compiled Object files, Static and Dynamic libs (Shared Objects)
+*.o
+*.a
+*.so
+
+# Folders
+_obj
+_test
+
+# Architecture specific extensions/prefixes
+*.[568vq]
+[568vq].out
+
+*.cgo1.go
+*.cgo2.c
+_cgo_defun.c
+_cgo_gotypes.go
+_cgo_export.*
+
+_testmain.go
+
+*.exe
+*.test
+*.prof
+
+# Vendored deps
+vendor/
+
+# test.json default DBURI
+storage.sqlite

--- a/test/config.json
+++ b/test/config.json
@@ -1,5 +1,6 @@
 {
   "metricsAddr": ":1971",
+  "dbURI": "file:storage.sqlite",
   "fetchConfig": {
     "interval": "120s",
     "timeout": "100s"
@@ -9,6 +10,11 @@
     "timeout": "500s",
     "certIssuerKeyPath": "test/issuer.key",
     "certIssuerPath": "test/issuer.pem"
+  },
+  "inclusionConfig": {
+    "interval": "630s",
+    "fetchBatchSize": 30,
+    "maxGetEntries": 30
   },
   "logs": [
     {

--- a/util/config.dist.json
+++ b/util/config.dist.json
@@ -1,5 +1,6 @@
 {
   "metricsAddr": ":1971",
+  "dbURI": "file:/etc/ct-woodpecker/storage.sqlite",
   "fetchConfig": {
     "interval": "120s",
     "timeout": "100s"
@@ -9,6 +10,11 @@
     "timeout": "500s",
     "certIssuerKeyPath": "/etc/ct-woodpecker/issuer.key",
     "certIssuerPath": "/etc/ct-woodpecker/issuer.pem"
+  },
+  "inclusionConfig": {
+    "interval": "630s",
+    "fetchBatchSize": 30,
+    "maxGetEntries": 30
   },
   "logs": [
     {

--- a/woodpecker/woodpecker_test.go
+++ b/woodpecker/woodpecker_test.go
@@ -61,6 +61,7 @@ func TestConfigValid(t *testing.T) {
 	}
 
 	validConfig := Config{
+		DBURI: "file:foobar.db",
 		FetchConfig: &STHFetchConfig{
 			Interval: "2s",
 			Timeout:  "1s",
@@ -70,6 +71,11 @@ func TestConfigValid(t *testing.T) {
 			Timeout:           "2s",
 			CertIssuerKeyPath: "⚷",
 			CertIssuerPath:    "foo",
+		},
+		InclusionConfig: &InclusionCheckerConfig{
+			Interval:       "120s",
+			FetchBatchSize: 64,
+			MaxGetEntries:  128,
 		},
 		Logs: validLogs,
 	}
@@ -169,6 +175,34 @@ func TestConfigValid(t *testing.T) {
 					Interval:          "2s",
 					Timeout:           "2s",
 					CertIssuerKeyPath: "⚷",
+				},
+				Logs: validLogs,
+			},
+		},
+		{
+			Name: "Log with inclusionCheckerConfig no submitConfig",
+			Config: Config{
+				InclusionConfig: &InclusionCheckerConfig{
+					Interval:       "2s",
+					FetchBatchSize: 128,
+					MaxGetEntries:  256,
+				},
+				Logs: validLogs,
+			},
+		},
+		{
+			Name: "Log with inclusionCheckerConfig, invalid interval",
+			Config: Config{
+				SubmitConfig: &CertSubmitConfig{
+					Interval:          "2s",
+					Timeout:           "2s",
+					CertIssuerKeyPath: "⚷",
+					CertIssuerPath:    "foo",
+				},
+				InclusionConfig: &InclusionCheckerConfig{
+					Interval:       "pretty-quickly-i-guess?",
+					FetchBatchSize: 128,
+					MaxGetEntries:  256,
 				},
 				Logs: validLogs,
 			},


### PR DESCRIPTION
`woodpecker.New` now supports providing `inclusionChecker` options and
a storage `DBURI`. This allows the command line `ct-woodpcker` to use
the `inclusionChecker`. The included example config files are updated to
use both features. The `.gitignore` is updated to ignore the default
suggested database file.

Resolves https://github.com/letsencrypt/ct-woodpecker/issues/42