### PR TITLE
cert-submitter: fix SCT serialization error.

### DIFF
--- a/monitor/cert_submitter.go
+++ b/monitor/cert_submitter.go
@@ -216,7 +216,7 @@ func (c certSubmitter) submitCertificate(cert *x509.Certificate, isPreCert bool)
 	}
 
 	if c.db != nil {
-		sctBytes, err := cttls.Marshal(sct)
+		sctBytes, err := cttls.Marshal(*sct)
 		if err != nil {
 			c.logger.Printf("!!! Error serializing SCT: %s", err)
 			c.stats.certStorageFailures.WithLabelValues("marshalling").Inc()


### PR DESCRIPTION
When the `certSubmitter` has storage configured it tries to serialize the
SCT from cert submissions to store in the storage using `cttls.Marshal`.
This means we must dereference the `*ct.SignedCertificateTimestamp`
to use it as an argument for marshaling, otherwise it will error. This
commit adds the required deref.

Resolves https://github.com/letsencrypt/ct-woodpecker/issues/46