### PR TITLE
Actually initialize the stop channel

### DIFF
--- a/monitor/monitor.go
+++ b/monitor/monitor.go
@@ -201,6 +201,7 @@ func New(opts MonitorOptions, logger *log.Logger, clk clock.Clock) (*Monitor, er
 			signatureChecker: sv,
 			logID:            big.NewInt(0).SetBytes(keyHash[:]).Int64(),
 			batchSize:        opts.InclusionOpts.FetchBatchSize,
+			stopChan:         make(chan bool, 1),
 		}
 	}
 


### PR DESCRIPTION
So that woodpecker can actually be stopped (still surprised trying to write to/read from a nil channel doesn't cause a panic).