### PR TITLE
inclusion-checker: fix off-by-one error.

### DIFF
--- a/monitor/inclusion_checker.go
+++ b/monitor/inclusion_checker.go
@@ -96,7 +96,7 @@ func (ic *inclusionChecker) checkInclusion() error {
 		inclusionErrors.WithLabelValues("getSTH").Inc()
 		return fmt.Errorf("error getting STH from %q: %s", ic.logURI, err)
 	}
-	newHead, entries, err := ic.getEntries(current, int64(sth.TreeSize))
+	newHead, entries, err := ic.getEntries(current, int64(sth.TreeSize)-1)
 	if err != nil {
 		inclusionErrors.WithLabelValues("getEntries").Inc()
 		return fmt.Errorf("error retrieving entries from %q: %s", ic.logURI, err)
@@ -129,7 +129,7 @@ func (ic *inclusionChecker) getEntries(start, end int64) (int64, []ct.LogEntry, 
 		end = start + ic.maxGetEntries
 	}
 	var allEntries []ct.LogEntry
-	for start <= end {
+	for start < end {
 		batchEnd := min(start+ic.batchSize, end)
 		entries, err := ic.client.GetEntries(context.Background(), start, batchEnd)
 		if err != nil {

--- a/monitor/inclusion_checker_test.go
+++ b/monitor/inclusion_checker_test.go
@@ -51,7 +51,7 @@ func TestGetEntries(t *testing.T) {
 		entries := []ct.LogEntry{{}, {}, {}}
 		return entries[start : end+1], nil
 	}
-	newHead, entries, err := ic.getEntries(0, 2)
+	newHead, entries, err := ic.getEntries(0, 3)
 	if err != nil {
 		t.Fatalf("Expected no error: %s", err)
 	}
@@ -68,7 +68,7 @@ func TestGetEntries(t *testing.T) {
 		entries := []ct.LogEntry{{}, {}, {}}
 		return []ct.LogEntry{entries[start]}, nil
 	}
-	newHead, entries, err = ic.getEntries(0, 2)
+	newHead, entries, err = ic.getEntries(0, 3)
 	if err != nil {
 		t.Fatalf("Expected no error: %s", err)
 	}
@@ -368,7 +368,7 @@ func TestCheckInclusion(t *testing.T) {
 	}
 
 	mc.GetSTHFunc = func(context.Context) (*ct.SignedTreeHead, error) {
-		return &ct.SignedTreeHead{TreeSize: 1}, nil
+		return &ct.SignedTreeHead{TreeSize: 2}, nil
 	}
 	mc.GetEntriesFunc = func(context.Context, int64, int64) ([]ct.LogEntry, error) {
 		return nil, errors.New("bad")


### PR DESCRIPTION
The second argument to `getEntries` is inclusive. When fetching to the
current treesize we need to fetch the entries up to treesize - 1.

Similarly, when looping we need to exit when start == end, meaning the
loop should run when start < end, not start <= end.