### PR TITLE
inclusionChecker: set `MaxGetEntries` from inclusionOptions.

### DIFF
--- a/monitor/monitor.go
+++ b/monitor/monitor.go
@@ -201,6 +201,7 @@ func New(opts MonitorOptions, logger *log.Logger, clk clock.Clock) (*Monitor, er
 			signatureChecker: sv,
 			logID:            big.NewInt(0).SetBytes(keyHash[:]).Int64(),
 			batchSize:        opts.InclusionOpts.FetchBatchSize,
+			maxGetEntries:    opts.InclusionOpts.MaxGetEntries,
 			stopChan:         make(chan bool, 1),
 		}
 	}


### PR DESCRIPTION
The `monitor.New` constructor that created the `inclusionChecker` struct
was not wiring through the `opts.InclusionOpts.MaxGetEntries` setting
from the provided inclusion checker configuration. This results in an
OOM condition in `getEntries` when no clipping on the end range is done
and an entire log's worth of entries are built up in a single slice.

Resolves https://github.com/letsencrypt/ct-woodpecker/issues/53