### PR TITLE
Separate stdout/stderr, common monitorChecker type.

### DIFF
--- a/cmd/ct-woodpecker/main.go
+++ b/cmd/ct-woodpecker/main.go
@@ -13,8 +13,12 @@ import (
 
 var (
 	clk    clock.Clock = clock.Default()
-	logger *log.Logger = log.New(
+	stdout *log.Logger = log.New(
 		os.Stdout,
+		path.Base(os.Args[0])+" ",
+		log.LstdFlags)
+	stderr *log.Logger = log.New(
+		os.Stderr,
 		path.Base(os.Args[0])+" ",
 		log.LstdFlags)
 )
@@ -33,7 +37,7 @@ func main() {
 	}
 
 	// Create a Woodpecker with the provided monitoring configuration
-	woodpecker, err := woodpecker.New(conf, logger, clk)
+	woodpecker, err := woodpecker.New(conf, stdout, stderr, clk)
 	if err != nil {
 		log.Fatalf("Unable to create ct-woodpecker: %s", err.Error())
 	}
@@ -44,5 +48,5 @@ func main() {
 	// Block the main goroutine waiting for signals while the monitors run in
 	// their own goroutines. WaitForSignal is provided a callback to cleanly
 	// shutdown the metrics HTTP server when a signal is caught.
-	cmd.WaitForSignal(logger, func() { woodpecker.Stop() })
+	cmd.WaitForSignal(stdout, func() { woodpecker.Stop() })
 }

--- a/monitor/cert_submitter_test.go
+++ b/monitor/cert_submitter_test.go
@@ -75,7 +75,7 @@ func TestSubmitCertificate(t *testing.T) {
 				SubmitCert:    true,
 				SubmitPreCert: true,
 			},
-		}, l, clk)
+		}, l, l, clk)
 	if err != nil {
 		t.Fatalf("Unexpected error from New(): %s", err.Error())
 	}
@@ -176,16 +176,20 @@ func (dc *dupeClient) GetSTHConsistency(_ context.Context, _ uint64, _ uint64) (
 func TestSubmitIncludedDupe(t *testing.T) {
 	mdb := &storage.MalleableTestDB{}
 	dc := dupeClient{}
-	c := certSubmitter{
-		db:         mdb,
-		logID:      1,
-		logURI:     "test-log",
-		stats:      certStats,
-		certIssuer: &x509.Certificate{Raw: []byte{1, 2, 3}},
-		client:     &dc,
-		logger:     log.New(os.Stdout, "", log.LstdFlags),
-		clk:        clock.New(),
-	}
+	c := newCertSubmitter(
+		monitorCheck{
+			logURI: "test-log",
+			logID:  1,
+			label:  "certSubmitter",
+			clk:    clock.New(),
+			stdout: log.New(os.Stdout, "", log.LstdFlags),
+			stderr: log.New(os.Stdout, "", log.LstdFlags),
+		},
+		&SubmitterOptions{
+			IssuerCert: &x509.Certificate{Raw: []byte{1, 2, 3}},
+		},
+		&dc,
+		mdb)
 
 	testCases := []struct {
 		setup       func()

--- a/monitor/common.go
+++ b/monitor/common.go
@@ -1,0 +1,55 @@
+package monitor
+
+import (
+	"fmt"
+	"log"
+
+	ctClient "github.com/google/certificate-transparency-go/client"
+	"github.com/jmhodges/clock"
+)
+
+// wrapRspErr takes an errors as input and if it is a ctClient.RspError
+// instance it is returned in a wrapped form that prints the HTTP response
+// status and body in the error message. All other error types are passed
+// through unmodified.
+func wrapRspErr(err error) error {
+	if err == nil {
+		return nil
+	}
+
+	// If it is an RspError instance, wrap it
+	if rspErr, ok := err.(ctClient.RspError); ok {
+		return fmt.Errorf("%s HTTP Response Status: %d HTTP Response Body: %q",
+			rspErr.Err, rspErr.StatusCode, string(rspErr.Body))
+	}
+
+	// If it wasn't an RspError instance, return as-is
+	return err
+}
+
+type monitorCheck struct {
+	logURI string
+	logID  int64
+	label  string
+	clk    clock.Clock
+	stdout *log.Logger
+	stderr *log.Logger
+}
+
+func (mc monitorCheck) logErrorf(format string, args ...interface{}) {
+	line := fmt.Sprintf(format, args...)
+	mc.logError(line)
+}
+
+func (mc monitorCheck) logError(msg string) {
+	mc.stderr.Print("[ERROR]", " ", mc.label, " ", mc.logURI, " : ", msg)
+}
+
+func (mc monitorCheck) logf(format string, args ...interface{}) {
+	line := fmt.Sprintf(format, args...)
+	mc.log(line)
+}
+
+func (mc monitorCheck) log(msg string) {
+	mc.stdout.Print(mc.label, " ", mc.logURI, " : ", msg)
+}

--- a/monitor/common_test.go
+++ b/monitor/common_test.go
@@ -1,0 +1,58 @@
+package monitor
+
+import (
+	"errors"
+	"fmt"
+	ctClient "github.com/google/certificate-transparency-go/client"
+	"testing"
+)
+
+func TestWrapRspErr(t *testing.T) {
+	normalErr := errors.New("just a normal error reporting for duty")
+
+	rspErr := ctClient.RspError{
+		Err:        normalErr,
+		StatusCode: 999,
+		Body:       []byte("This is the body of a ctClient.RspError"),
+	}
+
+	testCases := []struct {
+		Name        string
+		InputErr    error
+		ExpectedErr error
+	}{
+		{
+			Name:        "nil input err",
+			InputErr:    nil,
+			ExpectedErr: nil,
+		},
+		{
+			Name:        "non-RespError input err",
+			InputErr:    normalErr,
+			ExpectedErr: normalErr,
+		},
+		{
+			Name:     "rspError input err",
+			InputErr: rspErr,
+			ExpectedErr: fmt.Errorf("%s HTTP Response Status: %d HTTP Response Body: %q",
+				normalErr.Error(), rspErr.StatusCode, string(rspErr.Body)),
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.Name, func(t *testing.T) {
+			actualErr := wrapRspErr(tc.InputErr)
+			if tc.ExpectedErr == nil && actualErr != nil {
+				t.Fatalf("Expected err to be nil, was %#v", actualErr)
+			} else if tc.ExpectedErr != nil && actualErr == nil {
+				t.Fatalf("Expected err to be %#v, was nil", tc.ExpectedErr)
+			} else if tc.ExpectedErr != nil {
+				actual := actualErr.Error()
+				expected := tc.ExpectedErr.Error()
+				if actual != expected {
+					t.Errorf("Expected err %q got %q", expected, actual)
+				}
+			}
+		})
+	}
+}

--- a/monitor/sth_fetcher_test.go
+++ b/monitor/sth_fetcher_test.go
@@ -28,7 +28,7 @@ func TestObserveSTH(t *testing.T) {
 				Interval: fetchDuration,
 				Timeout:  time.Second,
 			},
-		}, l, clk)
+		}, l, l, clk)
 	if err != nil {
 		t.Fatalf("Unexpected error from New(): %s", err.Error())
 	}
@@ -129,7 +129,17 @@ func TestVerifySTHConsistency(t *testing.T) {
 	logURI := "test"
 
 	// Create a fetcher backed by an errorClient
-	f := newSTHFetcher(l, clk, errorClient{}, logURI, fetchInterval, time.Second)
+	f := newSTHFetcher(monitorCheck{
+		logURI: logURI,
+		stdout: l,
+		stderr: l,
+		clk:    clk,
+	},
+		&FetcherOptions{
+			Interval: fetchInterval,
+			Timeout:  time.Second,
+		},
+		errorClient{})
 
 	first := &ct.SignedTreeHead{
 		TreeSize:       1337,

--- a/test/integration_test.go
+++ b/test/integration_test.go
@@ -74,7 +74,7 @@ func woodpeckerRun(conf woodpecker.Config, duration time.Duration) (string, stri
 	clk := clock.Default()
 
 	// Create a Woodpecker with the provided monitoring configuration
-	woodpecker, err := woodpecker.New(conf, logger, clk)
+	woodpecker, err := woodpecker.New(conf, logger, logger, clk)
 	if err != nil {
 		return "", "", err
 	}
@@ -424,7 +424,7 @@ func TestCoordinatedSTHOmission(t *testing.T) {
 
 	slowCount, fastCount := 0, 0
 	for _, srv := range testServers {
-		expectedFetchLine := fmt.Sprintf(`sth-fetcher http://localhost%s : Fetching STH`,
+		expectedFetchLine := fmt.Sprintf(`sthFetcher http://localhost%s : Fetching STH`,
 			srv.Addr)
 		fetchLinesCount := strings.Count(stdout, expectedFetchLine)
 
@@ -506,7 +506,7 @@ func TestCoordinatedCertOmission(t *testing.T) {
 	// submissions made monitoring will be skewed!
 	for _, srv := range testServers {
 		expectedPrecertLine := fmt.Sprintf(
-			`Submitting precertificate to "http://localhost%s"`,
+			`certSubmitter http://localhost%s : Submitting precertificate`,
 			srv.Addr)
 		precertLineCount := strings.Count(stdout, expectedPrecertLine)
 		if precertLineCount < 2 {
@@ -515,7 +515,7 @@ func TestCoordinatedCertOmission(t *testing.T) {
 		}
 
 		expectedCertLine := fmt.Sprintf(
-			`Submitting certificate to "http://localhost%s"`,
+			`certSubmitter http://localhost%s : Submitting certificate`,
 			srv.Addr)
 		certLineCount := strings.Count(stdout, expectedCertLine)
 		if certLineCount < 2 {

--- a/woodpecker/woodpecker.go
+++ b/woodpecker/woodpecker.go
@@ -218,11 +218,12 @@ type Woodpecker struct {
 	metricsServer *http.Server
 }
 
-// New creates a Woodpecker from the provided configuration, logger and clock.
+// New creates a Woodpecker from the provided configuration, stdout logger,
+// stderr logger and clock.
 // If the configuration is invalid or an error occurs initializing the
 // woodpecker it is returned. The returned Woodpecker and its monitors are not
 // started until the Start() function is called.
-func New(c Config, logger *log.Logger, clk clock.Clock) (*Woodpecker, error) {
+func New(c Config, stdout, stderr *log.Logger, clk clock.Clock) (*Woodpecker, error) {
 	if err := c.Valid(); err != nil {
 		return nil, err
 	}
@@ -304,7 +305,7 @@ func New(c Config, logger *log.Logger, clk clock.Clock) (*Woodpecker, error) {
 				MaxGetEntries:  c.InclusionConfig.MaxGetEntries,
 			}
 		}
-		m, err := monitor.New(opts, logger, clk)
+		m, err := monitor.New(opts, stdout, stderr, clk)
 		if err != nil {
 			return nil, err
 		}
@@ -312,7 +313,7 @@ func New(c Config, logger *log.Logger, clk clock.Clock) (*Woodpecker, error) {
 	}
 
 	return &Woodpecker{
-		logger:        logger,
+		logger:        stdout,
 		monitors:      monitors,
 		metricsServer: initMetrics(c.MetricsAddr),
 	}, nil

--- a/woodpecker/woodpecker_test.go
+++ b/woodpecker/woodpecker_test.go
@@ -344,7 +344,7 @@ func TestNew(t *testing.T) {
 	clk.Set(time.Now())
 
 	// Creating a woodpecker with an invalid config should fail
-	_, err := New(Config{}, l, clk)
+	_, err := New(Config{}, l, l, clk)
 	if err == nil {
 		t.Errorf("expected err calling New() with invalid config, got nil")
 	}
@@ -367,7 +367,7 @@ func TestNew(t *testing.T) {
 			Timeout:  "1s",
 		},
 		Logs: logs,
-	}, l, clk)
+	}, l, l, clk)
 	if err != nil {
 		t.Fatalf("unexpected err calling New(): %s\n", err.Error())
 	}
@@ -398,7 +398,7 @@ func TestNew(t *testing.T) {
 			CertIssuerPath:    "../test/issuer.pem",
 		},
 		Logs: submitLogs,
-	}, l, clk)
+	}, l, l, clk)
 	if err != nil {
 		t.Fatalf("unexpected err calling New(): %s\n", err.Error())
 	}


### PR DESCRIPTION
The individual check types used by the `monitor` package
(`sthFetcher`, `certSubmitter`, `inclusionChecker`) now embed a common
`monitorChecker` type. This is used to bundle up the common config
parameters used by all the checkers and provide convenience functions
for logging.

There is now a separate logger for stdout/stderr. The `ct-woodpecker`
binary creates these with os.Stderr and os.Stdout. Programmatic users
(e.g. tests) are free to use the same logger for both the stdout and
stderr loggers for simplicity.

Resolves https://github.com/letsencrypt/ct-woodpecker/issues/36