### PR TITLE
Handle stale STHs.

### DIFF
--- a/monitor/common.go
+++ b/monitor/common.go
@@ -28,12 +28,13 @@ func wrapRspErr(err error) error {
 }
 
 type monitorCheck struct {
-	logURI string
-	logID  int64
-	label  string
-	clk    clock.Clock
-	stdout *log.Logger
-	stderr *log.Logger
+	logURI            string
+	logID             int64
+	maximumMergeDelay int
+	label             string
+	clk               clock.Clock
+	stdout            *log.Logger
+	stderr            *log.Logger
 }
 
 func (mc monitorCheck) logErrorf(format string, args ...interface{}) {

--- a/monitor/monitor_test.go
+++ b/monitor/monitor_test.go
@@ -39,8 +39,9 @@ func TestNew(t *testing.T) {
 	// Creating a monitor with vaild configuration should not fail
 	m, err := New(
 		MonitorOptions{
-			LogURI: logURI,
-			LogKey: logKey,
+			LogURI:            logURI,
+			LogKey:            logKey,
+			MaximumMergeDelay: 9999,
 			FetchOpts: &FetcherOptions{
 				Interval: fetchDuration,
 				Timeout:  time.Second,
@@ -98,8 +99,9 @@ func TestNew(t *testing.T) {
 	// Creating a monitor with a issuer key and cert should not error
 	m, err = New(
 		MonitorOptions{
-			LogURI: logURI,
-			LogKey: logKey,
+			LogURI:            logURI,
+			LogKey:            logKey,
+			MaximumMergeDelay: 9999,
 			SubmitOpts: &SubmitterOptions{
 				Timeout:       time.Second,
 				Interval:      fetchDuration,
@@ -170,6 +172,7 @@ func (c errorClient) GetSTHConsistency(_ context.Context, _ uint64, _ uint64) ([
 // proof from `GetSTHConsistency`
 type mockClient struct {
 	timestamp time.Time
+	treesize  uint64
 	proof     [][]byte
 }
 
@@ -178,6 +181,7 @@ func (c mockClient) GetSTH(_ context.Context) (*ct.SignedTreeHead, error) {
 	ts := c.timestamp.UnixNano() / int64(time.Millisecond)
 	return &ct.SignedTreeHead{
 		Timestamp: uint64(ts),
+		TreeSize:  c.treesize,
 	}, nil
 }
 

--- a/test/config.json
+++ b/test/config.json
@@ -20,6 +20,7 @@
     {
       "uri": "https://birch.ct.letsencrypt.org/2018",
       "key": "MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAElgyN7ptarCAX5krBwDwjhHM+b0xJjCKke+Dfr3GWSbLm3eO7muXRo8FDDdpdiRpnG4NJT0bdzq5YEer4C2eZ+g==",
+      "maximum_merge_delay": 86399,
       "start": "318848629",
       "submitPreCert": true,
       "submitCert": true

--- a/util/config.dist.json
+++ b/util/config.dist.json
@@ -20,7 +20,12 @@
     {
       "uri": "https://birch.ct.letsencrypt.org/2018",
       "key": "MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAElgyN7ptarCAX5krBwDwjhHM+b0xJjCKke+Dfr3GWSbLm3eO7muXRo8FDDdpdiRpnG4NJT0bdzq5YEer4C2eZ+g==",
-      "start": "318848629",
+      "submitPreCert": true,
+      "submitCert": true
+    },
+    {
+      "uri": "https://spruce.ct.letsencrypt.org/2018",
+      "key": "MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEFq93Kkw3d9j25WKWHfgix0tNw+fbO3nWy3whKl3KtbkDTqIT2zUCPfM0BNFGoSgK4ikykT5MTyMIVFzULbO+UQ==",
       "submitPreCert": true,
       "submitCert": true
     }

--- a/woodpecker/woodpecker_test.go
+++ b/woodpecker/woodpecker_test.go
@@ -43,6 +43,10 @@ func TestLogConfigValid(t *testing.T) {
 			Config: LogConfig{URI: "https://test.com", Key: "⚷", Start: "0"},
 		},
 		{
+			Name:   "Invalid maximum merge delay",
+			Config: LogConfig{URI: "https://test.com", Key: "⚷", MaximumMergeDelay: -1},
+		},
+		{
 			Name:   "Valid log config",
 			Config: LogConfig{URI: "https://test.com", Key: "⚷"},
 			Valid:  true,
@@ -277,6 +281,7 @@ func TestConfigLoad(t *testing.T) {
     {
       "uri": "https://birch.ct.letsencrypt.org/2018",
       "key": "MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAElgyN7ptarCAX5krBwDwjhHM+b0xJjCKke+Dfr3GWSbLm3eO7muXRo8FDDdpdiRpnG4NJT0bdzq5YEer4C2eZ+g==",
+      "maximum_merge_delay": 1234,
       "submitCert": true
     }
   ]
@@ -318,9 +323,10 @@ func TestConfigLoad(t *testing.T) {
 				},
 				Logs: []LogConfig{
 					{
-						URI:        "https://birch.ct.letsencrypt.org/2018",
-						Key:        "MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAElgyN7ptarCAX5krBwDwjhHM+b0xJjCKke+Dfr3GWSbLm3eO7muXRo8FDDdpdiRpnG4NJT0bdzq5YEer4C2eZ+g==",
-						SubmitCert: true,
+						URI:               "https://birch.ct.letsencrypt.org/2018",
+						Key:               "MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAElgyN7ptarCAX5krBwDwjhHM+b0xJjCKke+Dfr3GWSbLm3eO7muXRo8FDDdpdiRpnG4NJT0bdzq5YEer4C2eZ+g==",
+						MaximumMergeDelay: 1234,
+						SubmitCert:        true,
 					},
 				},
 			},


### PR DESCRIPTION
If a log gives back a valid STH for a smaller treesize than the previously seen STH (a stale STH) don't overwrite prevSTH and don't check consistency proof. If the stale STH is older than the log's MMD, print an error.

Resolves https://github.com/letsencrypt/ct-woodpecker/issues/61