### PR TITLE
cttestsrv: fix for upstream Trillian `ReadRevision`.

### DIFF
--- a/test/cttestsrv/log.go
+++ b/test/cttestsrv/log.go
@@ -227,7 +227,12 @@ func (log *testLog) getProof(first, second int64) (*trillian.GetConsistencyProof
 		return nil, err
 	}
 
-	proof, err := fetchNodesAndBuildProof(context.Background(), tx, log.activeTree.hasher, tx.ReadRevision(), 0, nodeFetches)
+	readRevision, err := tx.ReadRevision(context.Background())
+	if err != nil {
+		return nil, err
+	}
+
+	proof, err := fetchNodesAndBuildProof(context.Background(), tx, log.activeTree.hasher, readRevision, 0, nodeFetches)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
The upstream Trillian project changed the `tx.ReadRevision()` function to accept a context argument and return an error in addition to the tree revision. We must pass the right arg and handle the err now.