### PR TITLE
sthFetcher: Remove debug prints, fix data race

### DIFF
--- a/monitor/sth_fetcher.go
+++ b/monitor/sth_fetcher.go
@@ -190,8 +190,6 @@ func (f *sthFetcher) observeSTH() {
 	// already. We do want to print an error if the stale STH we got back is older
 	// than the log's MMD
 	if f.prevSTH != nil && f.prevSTH.TreeSize > newSTH.TreeSize {
-		fmt.Printf("Age: %d\n", int(sthAge.Seconds()))
-		fmt.Printf("MMD: %d\n", f.maximumMergeDelay)
 		if int(sthAge.Seconds()) > f.maximumMergeDelay {
 			f.logErrorf("Fetched stale STH older than log MMD. Prev TreeSize is %d. New STH has TreeSize %d and Age: %s",
 				f.prevSTH.TreeSize, newSTH.TreeSize, sthAge)

--- a/monitor/sth_fetcher.go
+++ b/monitor/sth_fetcher.go
@@ -196,7 +196,7 @@ func (f *sthFetcher) observeSTH() {
 		}
 		return
 	} else if f.prevSTH != nil {
-		go f.verifySTHConsistency(f.prevSTH, newSTH)
+		f.verifySTHConsistency(f.prevSTH, newSTH)
 	}
 
 	f.prevSTH = newSTH

--- a/monitor/sth_fetcher_test.go
+++ b/monitor/sth_fetcher_test.go
@@ -267,6 +267,7 @@ func TestStaleSTHHandling(t *testing.T) {
 			Timeout:  time.Second,
 		},
 		errorClient{})
+	f.verifier = mockVerifier{}
 
 	// First return a 2 hour old STH
 	timestampAge := 2 * time.Hour
@@ -294,6 +295,7 @@ func TestStaleSTHHandling(t *testing.T) {
 	f.client = mockClient{
 		timestamp: sthTimestamp,
 		treesize:  20,
+		proof:     [][]byte{{0xFA, 0xCA, 0xDE}},
 	}
 
 	// Observe the STH and verify prevSTH is set correctly

--- a/test/cttestsrv/log.go
+++ b/test/cttestsrv/log.go
@@ -227,7 +227,12 @@ func (log *testLog) getProof(first, second int64) (*trillian.GetConsistencyProof
 		return nil, err
 	}
 
-	proof, err := fetchNodesAndBuildProof(context.Background(), tx, log.activeTree.hasher, tx.ReadRevision(), 0, nodeFetches)
+	readRevision, err := tx.ReadRevision(context.Background())
+	if err != nil {
+		return nil, err
+	}
+
+	proof, err := fetchNodesAndBuildProof(context.Background(), tx, log.activeTree.hasher, readRevision, 0, nodeFetches)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
There's no need to spawn a separate goroutine to verify consistency proofs. This also avoids a datarace when unit tests change the client mock out from under the sthFetcher.

Along the way this also fixes a upstream breakage in the cttestsrv.