### PR TITLE
cttestsrv: fix upstream memory storage API change.

### DIFF
--- a/test/cttestsrv/log.go
+++ b/test/cttestsrv/log.go
@@ -22,6 +22,7 @@ import (
 	"github.com/google/trillian/log"
 	"github.com/google/trillian/merkle"
 	"github.com/google/trillian/merkle/hashers"
+	"github.com/google/trillian/monitoring"
 	"github.com/google/trillian/quota"
 	"github.com/google/trillian/storage"
 	"github.com/google/trillian/storage/memory"
@@ -111,8 +112,9 @@ func makeTree(name string, key *ecdsa.PrivateKey) (*testTree, error) {
 		return nil, err
 	}
 
-	logStorage := memory.NewLogStorage(nil)
-	adminStorage := memory.NewAdminStorage(logStorage)
+	treeStorage := memory.NewTreeStorage()
+	logStorage := memory.NewLogStorage(nil, monitoring.InertMetricFactory{})
+	adminStorage := memory.NewAdminStorage(treeStorage)
 
 	sequencer := log.NewSequencer(hasher, timeSource, logStorage, signer, nil, quota.Noop())
 

--- a/test/cttestsrv/log.go
+++ b/test/cttestsrv/log.go
@@ -113,7 +113,7 @@ func makeTree(name string, key *ecdsa.PrivateKey) (*testTree, error) {
 	}
 
 	treeStorage := memory.NewTreeStorage()
-	logStorage := memory.NewLogStorage(nil, monitoring.InertMetricFactory{})
+	logStorage := memory.NewLogStorage(treeStorage, monitoring.InertMetricFactory{})
 	adminStorage := memory.NewAdminStorage(treeStorage)
 
 	sequencer := log.NewSequencer(hasher, timeSource, logStorage, signer, nil, quota.Noop())


### PR DESCRIPTION
The upstream Trillian project [refactored the memory storage provider](https://github.com/google/trillian/commit/55141304712f380c1e199caf76fbee1e226cc6b5) and since we don't vendor dependencies this broke the cttestsrv.