### PR TITLE
Fix golangci nits

### DIFF
--- a/cmd/ct-woodpecker/main.go
+++ b/cmd/ct-woodpecker/main.go
@@ -12,7 +12,7 @@ import (
 )
 
 var (
-	clk    clock.Clock = clock.Default()
+	clk    clock.Clock = clock.New()
 	stdout *log.Logger = log.New(
 		os.Stdout,
 		path.Base(os.Args[0])+" ",

--- a/monitor/cert_submitter.go
+++ b/monitor/cert_submitter.go
@@ -345,7 +345,7 @@ func (c certSubmitter) submitIncludedDupe() error {
 		c.stats.certStorageFailures.WithLabelValues(c.logURI, "marshalling").Inc()
 		return fmt.Errorf("failed to parse returned SCT: %s", err)
 	}
-	if bytes.Compare(sctBytes, cert.SCT) != 0 {
+	if !bytes.Equal(sctBytes, cert.SCT) {
 		// non-matching SCT, add to database for future inclusion checking
 		err = c.db.AddCert(c.logID, &storage.SubmittedCert{
 			Cert:      cert.Cert,

--- a/monitor/cert_submitter.go
+++ b/monitor/cert_submitter.go
@@ -220,8 +220,7 @@ func (c certSubmitter) submit(cert []byte, precert bool) (*ct.SignedCertificateT
 		chain = append(chain, ct.ASN1Cert{Data: c.certIssuer.Raw})
 	}
 
-	var submissionMethod func(context.Context, []ct.ASN1Cert) (*ct.SignedCertificateTimestamp, error)
-	submissionMethod = c.client.AddChain
+	submissionMethod := c.client.AddChain
 	certKind := "certificate"
 	if precert {
 		submissionMethod = c.client.AddPreChain

--- a/pki/certs_test.go
+++ b/pki/certs_test.go
@@ -66,7 +66,7 @@ func TestIssueCertificate(t *testing.T) {
 func TestIssueTestCertificate(t *testing.T) {
 	issuerKey, _ := RandKey()
 	issuerCert := &x509.Certificate{}
-	clk := clock.Default()
+	clk := clock.New()
 
 	certPair, err := IssueTestCertificate(issuerKey, issuerCert, clk)
 	if err != nil {

--- a/storage/storage.go
+++ b/storage/storage.go
@@ -133,11 +133,10 @@ func (s *impl) GetIndex(logID int64) (int64, error) {
 	}
 	var index int64
 	defer func() { _ = rows.Close() }()
-	for rows.Next() {
+	if rows.Next() {
 		if err := rows.Scan(&index); err != nil {
 			return 0, err
 		}
-		break
 	}
 	if err := rows.Err(); err != nil {
 		return 0, err

--- a/test/cttestsrv/log.go
+++ b/test/cttestsrv/log.go
@@ -62,8 +62,6 @@ type testLog struct {
 
 	treeA *testTree
 	treeB *testTree
-
-	adminStorage storage.AdminStorage
 }
 
 // makeTree constructs a testTree with the given name/description and private

--- a/test/cttestsrv/management_handlers.go
+++ b/test/cttestsrv/management_handlers.go
@@ -142,5 +142,4 @@ func (is *IntegrationSrv) switchTreesHandler(w http.ResponseWriter, r *http.Requ
 	_ = is.SwitchTrees()
 	is.logger.Printf("%s %s request completed.", is.Addr, r.URL.Path)
 	w.WriteHeader(http.StatusOK)
-	return
 }

--- a/woodpecker/woodpecker.go
+++ b/woodpecker/woodpecker.go
@@ -229,7 +229,6 @@ func (c *Config) Load(file string) error {
 // is one `monitor.Monitor` for each monitored logs.
 type Woodpecker struct {
 	logger        *log.Logger
-	clk           clock.Clock
 	monitors      []*monitor.Monitor
 	metricsServer *http.Server
 }


### PR DESCRIPTION
This PR addresses the low hanging nits [flagged by GolangCI](https://golangci.com/r/github.com/letsencrypt/ct-woodpecker).

It leaves three "megacheck" findings yet to be addressed in the `cttestsrv`:
* signedLogRoot.TreeSize is deprecated: TreeSize moved to LogRoot.
* signedLogRoot.TimestampNanos is deprecated: TimestampNanos moved to LogRoot.
* signedLogRoot.RootHash is deprecated: RootHash moved to LogRoot.

All of the above are a result of https://github.com/google/trillian/commit/0c12c8487309740c70e2da695f3c8043cb4f11e1 - it looks like the `certificate-transparency-go` ctfe is still using the deprecated fields so I think we can ignore these for now. I _think_ fixing it will require unserializing the `log_root []byte` from the response and that's too fiddly for my low-hanging PR.