### PR TITLE
CI: Remove goveralls -repotoken argument.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,6 +24,6 @@ before_script:
 script:
   - go vet -mod=vendor ./...
   - go test -mod=vendor -v -race -covermode=atomic -coverprofile=coverage.out -tags=integration ./...
-  - goveralls -coverprofile=coverage.out -service=travis-ci -repotoken $COVERALLS_TOKEN
+  - goveralls -coverprofile=coverage.out -service=travis-ci
   - ct-woodpecker -config ./test/config/config.json &
   - sleep 30s; killall ct-woodpecker


### PR DESCRIPTION
Leaving it in causes external PRs to fail because the encrypted COVERALLS_TOKEN env var isn't available and an empty `-repotoken` argument is invalid (See e.g. https://travis-ci.org/letsencrypt/ct-woodpecker/builds/469815134).

We don't need the `-repotoken` at all: it is only useful for private Github repositories.