### PR TITLE
Fix off-by-one error in checkInclusion.

### DIFF
--- a/monitor/inclusion_checker.go
+++ b/monitor/inclusion_checker.go
@@ -168,7 +168,7 @@ func (ic *inclusionChecker) checkInclusion() error {
 				"Unable to get entries for consistency check", newTreeSize, current)
 		return nil
 	}
-	newHead, entries, err := ic.getEntries(current, newTreeSize)
+	newHead, entries, err := ic.getEntries(current, newTreeSize-1)
 	if err != nil {
 		inclusionErrors.WithLabelValues(ic.logURI, "getEntries").Inc()
 		return fmt.Errorf("error retrieving entries from %q: %s", ic.logURI, err)


### PR DESCRIPTION
If tree size is X, the highest value we can have for `end` in
get-entries is X-1.