### PR TITLE
Remove FetchBatchSize and update other comments.

### DIFF
--- a/monitor/inclusion_checker_test.go
+++ b/monitor/inclusion_checker_test.go
@@ -55,9 +55,7 @@ func TestGetEntries(t *testing.T) {
 			stdout: log.New(os.Stdout, "", log.LstdFlags),
 			stderr: log.New(os.Stdout, "", log.LstdFlags),
 		},
-		&InclusionOptions{
-			FetchBatchSize: 0,
-		},
+		&InclusionOptions{},
 		mc,
 		logKey,
 		mdb)
@@ -339,9 +337,7 @@ func TestCheckInclusion(t *testing.T) {
 			stdout: log.New(os.Stdout, "", log.LstdFlags),
 			stderr: log.New(os.Stdout, "", log.LstdFlags),
 		},
-		&InclusionOptions{
-			FetchBatchSize: 1000,
-		},
+		&InclusionOptions{},
 		mc,
 		logKey,
 		mdb)

--- a/monitor/inclusion_checker_test.go
+++ b/monitor/inclusion_checker_test.go
@@ -71,7 +71,10 @@ func TestGetEntries(t *testing.T) {
 	// return three entries, one at a time (because batchSize is 0)
 	mc.GetEntriesFunc = func(_ context.Context, start, end int64) ([]ct.LogEntry, error) {
 		entries := []ct.LogEntry{{}, {}, {}}
-		return entries[start : end+1], nil
+		if int(end) > len(entries) {
+			end = int64(len(entries)) - 1
+		}
+		return entries[start:end], nil
 	}
 	ic.client = mc
 	newHead, entries, err := ic.getEntries(0, 3)

--- a/test/config/ct-woodpecker.docker.json
+++ b/test/config/ct-woodpecker.docker.json
@@ -6,15 +6,34 @@
     "interval": "20s",
     "timeout": "5s"
   },
+  "submitConfig": {
+    "interval": "5s",
+    "timeout": "5s",
+    "certIssuerKeyPath": "/test/issuer.key",
+    "certIssuerPath": "/test/issuer.pem"
+  },
+  "inclusionConfig": {
+    "interval": "30s",
+    "maxGetEntries": 30
+  },
   "logs": [
     {
-      "uri": "https://maple.ct.letsencrypt.org/2019",
-      "key": "MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEAg3+vFOesFW51rKECekioAt9Zo50atRoOJ0qLxF7DIEHsHneXLEpgO1WMreleRy1vEbUJD7TXoH9r8qSDGvyew==",
+      "uri": "http://log-one:4600",
+      "key": "MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEYggOxPnPkzKBIhTacSYoIfnSL2jPugcbUKx83vFMvk5gKAz/AGe87w20riuPwEGn229hKVbEKHFB61NIqNHC3Q==",
       "windowStart": "2000-01-01T00:00:00Z",
-      "windowEnd": "2020-01-01T00:00:00Z",
-      "maximum_merge_delay": 86400,
+      "windowEnd": "2001-01-01T00:00:00Z",
+      "maximum_merge_delay": 120,
       "submitPreCert": false,
-      "submitCert": false
+      "submitCert": true
+    },
+    {
+      "uri": "http://log-two:4601",
+      "key": "MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEKtnFevaXV/kB8dmhCNZHmxKVLcHX1plaAsY9LrKilhYxdmQZiu36LvAvosTsqMVqRK9a96nC8VaxAdaHUbM8EA==",
+      "windowStart": "2019-01-01T00:00:00Z",
+      "windowEnd": "2099-01-01T00:00:00Z",
+      "maximum_merge_delay": 120,
+      "submitPreCert": false,
+      "submitCert": true
     }
   ]
 }

--- a/test/config/ct-woodpecker.docker.json
+++ b/test/config/ct-woodpecker.docker.json
@@ -6,35 +6,15 @@
     "interval": "20s",
     "timeout": "5s"
   },
-  "submitConfig": {
-    "interval": "5s",
-    "timeout": "5s",
-    "certIssuerKeyPath": "/test/issuer.key",
-    "certIssuerPath": "/test/issuer.pem"
-  },
-  "inclusionConfig": {
-    "interval": "30s",
-    "fetchBatchSize": 30,
-    "maxGetEntries": 30
-  },
   "logs": [
     {
-      "uri": "http://log-one:4600",
-      "key": "MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEYggOxPnPkzKBIhTacSYoIfnSL2jPugcbUKx83vFMvk5gKAz/AGe87w20riuPwEGn229hKVbEKHFB61NIqNHC3Q==",
+      "uri": "https://maple.ct.letsencrypt.org/2019",
+      "key": "MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEAg3+vFOesFW51rKECekioAt9Zo50atRoOJ0qLxF7DIEHsHneXLEpgO1WMreleRy1vEbUJD7TXoH9r8qSDGvyew==",
       "windowStart": "2000-01-01T00:00:00Z",
-      "windowEnd": "2001-01-01T00:00:00Z",
-      "maximum_merge_delay": 120,
+      "windowEnd": "2020-01-01T00:00:00Z",
+      "maximum_merge_delay": 86400,
       "submitPreCert": false,
-      "submitCert": true
-    },
-    {
-      "uri": "http://log-two:4601",
-      "key": "MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEKtnFevaXV/kB8dmhCNZHmxKVLcHX1plaAsY9LrKilhYxdmQZiu36LvAvosTsqMVqRK9a96nC8VaxAdaHUbM8EA==",
-      "windowStart": "2019-01-01T00:00:00Z",
-      "windowEnd": "2099-01-01T00:00:00Z",
-      "maximum_merge_delay": 120,
-      "submitPreCert": false,
-      "submitCert": true
+      "submitCert": false
     }
   ]
 }

--- a/test/config/ct-woodpecker.docker.json
+++ b/test/config/ct-woodpecker.docker.json
@@ -14,7 +14,7 @@
   },
   "inclusionConfig": {
     "interval": "30s",
-    "maxGetEntries": 30
+    "maxGetEntries": 3000
   },
   "logs": [
     {

--- a/test/config/ct-woodpecker.localdev.json
+++ b/test/config/ct-woodpecker.localdev.json
@@ -14,8 +14,7 @@
   },
   "inclusionConfig": {
     "interval": "30s",
-    "fetchBatchSize": 30,
-    "maxGetEntries": 30
+    "maxGetEntries": 3000
   },
   "logs": [
     {

--- a/util/config.dist.json
+++ b/util/config.dist.json
@@ -13,8 +13,7 @@
   },
   "inclusionConfig": {
     "interval": "630s",
-    "fetchBatchSize": 30,
-    "maxGetEntries": 30
+    "maxGetEntries": 30000
   },
   "logs": [
     {

--- a/util/config.dist.json
+++ b/util/config.dist.json
@@ -13,7 +13,7 @@
   },
   "inclusionConfig": {
     "interval": "630s",
-    "maxGetEntries": 30000
+    "maxGetEntries": 3000
   },
   "logs": [
     {

--- a/util/config.dist.json
+++ b/util/config.dist.json
@@ -12,7 +12,7 @@
     "certIssuerPath": "/etc/ct-woodpecker/issuer.pem"
   },
   "inclusionConfig": {
-    "interval": "630s",
+    "interval": "60s",
     "maxGetEntries": 3000
   },
   "logs": [

--- a/woodpecker/woodpecker.go
+++ b/woodpecker/woodpecker.go
@@ -63,6 +63,9 @@ type InclusionCheckerConfig struct {
 	// How frequently to check the log for new entries (e.g. 2s, 1m)
 	Interval string
 	// The maximum number of entries to consider each Interval.
+	// The rate Interval / MaxGetEntries governs how many entries the inclusion
+	// checker can process per second, and it should be significantly higher than
+	// the expected growth rate of the log.
 	MaxGetEntries int64
 }
 

--- a/woodpecker/woodpecker.go
+++ b/woodpecker/woodpecker.go
@@ -60,9 +60,10 @@ type CertSubmitConfig struct {
 // InclusionCheckerConfig describes the configuration for checking submitted
 // certificates have been included in a monitored log periodically.
 type InclusionCheckerConfig struct {
-	Interval       string
-	FetchBatchSize int64
-	MaxGetEntries  int64
+	// How frequently to check the log for new entries (e.g. 2s, 1m)
+	Interval string
+	// The maximum number of entries to consider each Interval.
+	MaxGetEntries int64
 }
 
 // Config is a struct holding woodpecker configuration. A woodpecker can be
@@ -98,7 +99,7 @@ type LogConfig struct {
 	URI string
 	// Base64 encoded public key for the CT log
 	Key string
-	// Maximum merge delay for the log
+	// Maximum merge delay for the log (in seconds)
 	MaximumMergeDelay int `json:"maximum_merge_delay"`
 	// TreeSize to start at when checking for inclusion
 	Start string
@@ -361,10 +362,9 @@ func New(c Config, stdout, stderr *log.Logger, clk clock.Clock) (*Woodpecker, er
 				startIndex, _ = strconv.ParseInt(logConf.Start, 10, 64)
 			}
 			opts.InclusionOpts = &monitor.InclusionOptions{
-				Interval:       inclusionInterval,
-				FetchBatchSize: c.InclusionConfig.FetchBatchSize,
-				MaxGetEntries:  c.InclusionConfig.MaxGetEntries,
-				StartIndex:     startIndex,
+				Interval:      inclusionInterval,
+				MaxGetEntries: c.InclusionConfig.MaxGetEntries,
+				StartIndex:    startIndex,
 			}
 		}
 		m, err := monitor.New(opts, stdout, stderr, clk)

--- a/woodpecker/woodpecker_test.go
+++ b/woodpecker/woodpecker_test.go
@@ -85,9 +85,8 @@ func TestConfigValid(t *testing.T) {
 			CertIssuerPath:    "foo",
 		},
 		InclusionConfig: &InclusionCheckerConfig{
-			Interval:       "120s",
-			FetchBatchSize: 64,
-			MaxGetEntries:  128,
+			Interval:      "120s",
+			MaxGetEntries: 128,
 		},
 		Logs: validLogs,
 	}
@@ -195,9 +194,8 @@ func TestConfigValid(t *testing.T) {
 			Name: "Log with inclusionCheckerConfig no submitConfig",
 			Config: Config{
 				InclusionConfig: &InclusionCheckerConfig{
-					Interval:       "2s",
-					FetchBatchSize: 128,
-					MaxGetEntries:  256,
+					Interval:      "2s",
+					MaxGetEntries: 256,
 				},
 				Logs: validLogs,
 			},
@@ -212,9 +210,8 @@ func TestConfigValid(t *testing.T) {
 					CertIssuerPath:    "foo",
 				},
 				InclusionConfig: &InclusionCheckerConfig{
-					Interval:       "pretty-quickly-i-guess?",
-					FetchBatchSize: 128,
-					MaxGetEntries:  256,
+					Interval:      "pretty-quickly-i-guess?",
+					MaxGetEntries: 256,
 				},
 				Logs: validLogs,
 			},


### PR DESCRIPTION
FetchBatchSize didn't really need to be configurable, since we can
always request a reasonably large size, and logs will give us back the
maximum that they will allow up to that size. Having fewer config options
makes the tool easier to use.

This also adds godoc documenting some config options.