### PR TITLE
Fix handling of notBefore/notAfter in issued certs

### DIFF
--- a/pki/certs_test.go
+++ b/pki/certs_test.go
@@ -157,14 +157,83 @@ func TestIssueTestCertificate(t *testing.T) {
 		return foundPoison
 	}
 	if !findCTPoison(certPair.PreCert) {
-		t.Errorf("PreCert was missing expected CT Poision Extension ID")
+		t.Errorf("PreCert was missing expected CT Poison Extension ID")
 	}
 	if findCTPoison(certPair.Cert) {
-		t.Errorf("Cert had unexpected CT Poision Extension ID")
+		t.Errorf("Cert had unexpected CT Poison Extension ID")
 	}
 }
 
 func TestIssueTestCertificateWindow(t *testing.T) {
+	issuerKey, _ := RandKey()
+	issuerCert := &x509.Certificate{}
+
+	windowStart, _ := time.Parse(time.RFC3339, "2000-01-01T00:00:00Z")
+	windowEnd, _ := time.Parse(time.RFC3339, "2001-01-01T00:00:00Z")
+
+	shortFormat := func(t time.Time) string {
+		return t.Format("2006-01-02")
+	}
+
+	testCases := []struct {
+		now, notBefore, notAfter string
+	}{
+		{now: "1995-05-05", notBefore: "1995-05-05", notAfter: "2000-12-31"},
+		{now: "2000-03-03", notBefore: "2000-03-03", notAfter: "2000-12-31"},
+		{now: "2000-12-12", notBefore: "2000-12-12", notAfter: "2000-12-31"},
+		{now: "2019-04-17", notBefore: "2000-10-02", notAfter: "2000-12-31"},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.now, func(t *testing.T) {
+			now, err := time.Parse("2006-01-02", tc.now)
+			if err != nil {
+				t.Fatalf("Parsing %q: %s", tc.now, err)
+			}
+			clk := clock.NewFake()
+			clk.Set(now)
+
+			// Issue a cert pair with specific WindowStart and WindowEnd
+			certPair, err := IssueTestCertificate(issuerKey, issuerCert, clk, &windowStart, &windowEnd)
+			if err != nil {
+				t.Fatalf("unexpected error from IssueTestCertificate: %s", err.Error())
+			}
+
+			if certPair.PreCert == nil {
+				t.Fatalf("unexpected nil PreCert in CertPair returned from IssueTestCertificate")
+			}
+
+			if certPair.Cert == nil {
+				t.Fatalf("unexpected nil Cert in CertPair returned from IssueTestCertificate")
+			}
+
+			// Check the precert notbefore/notafter match expected
+			notBefore := shortFormat(certPair.PreCert.NotBefore)
+			notAfter := shortFormat(certPair.PreCert.NotAfter)
+			if notBefore != tc.notBefore {
+				t.Errorf("preCert notBefore was %q, expected %q",
+					notBefore, tc.notBefore)
+			}
+			if notAfter != tc.notAfter {
+				t.Errorf("preCert notAfter was %q, expected %q",
+					notAfter, tc.notAfter)
+			}
+			// Check that the cert notbefore/notafter match expected
+			notBefore = shortFormat(certPair.Cert.NotBefore)
+			notAfter = shortFormat(certPair.Cert.NotAfter)
+			if notBefore != tc.notBefore {
+				t.Errorf("cert notBefore was %q, expected %q",
+					notBefore, tc.notBefore)
+			}
+			if notAfter != tc.notAfter {
+				t.Errorf("cert notAfter was %q, expected %q",
+					notAfter, tc.notAfter)
+			}
+		})
+	}
+}
+
+func TestIssueTestCertificateNoWindow(t *testing.T) {
 	issuerKey, _ := RandKey()
 	issuerCert := &x509.Certificate{}
 	clk := clock.New()
@@ -189,7 +258,7 @@ func TestIssueTestCertificateWindow(t *testing.T) {
 
 	// Check that the precert notbefore/notafter match defaults
 	now := shortFormat(clk.Now())
-	defaultNotAfter := shortFormat(clk.Now().AddDate(0, 0, 89))
+	defaultNotAfter := shortFormat(clk.Now().AddDate(0, 0, 90))
 	notBefore := shortFormat(certPair.PreCert.NotBefore)
 	notAfter := shortFormat(certPair.PreCert.NotAfter)
 	if notBefore != now {
@@ -211,48 +280,5 @@ func TestIssueTestCertificateWindow(t *testing.T) {
 	if notAfter != defaultNotAfter {
 		t.Errorf("cert notAfter was %q, expected %q",
 			notAfter, defaultNotAfter)
-	}
-
-	windowStart, _ := time.Parse(time.RFC3339, "2000-01-01T00:00:00Z")
-	windowEnd, _ := time.Parse(time.RFC3339, "2001-01-01T00:00:00Z")
-
-	// Issue a cert pair with specific WindowStart and WindowEnd
-	certPair, err = IssueTestCertificate(issuerKey, issuerCert, clk, &windowStart, &windowEnd)
-	if err != nil {
-		t.Fatalf("unexpected error from IssueTestCertificate: %s", err.Error())
-	}
-
-	if certPair.PreCert == nil {
-		t.Fatalf("unexpected nil PreCert in CertPair returned from IssueTestCertificate")
-	}
-
-	if certPair.Cert == nil {
-		t.Fatalf("unexpected nil Cert in CertPair returned from IssueTestCertificate")
-	}
-
-	expectedStartDate := shortFormat(windowStart)
-	expectedEndDate := shortFormat(windowEnd.AddDate(0, 0, -1))
-
-	// Check the precert notbefore/notafter match expected
-	notBefore = shortFormat(certPair.PreCert.NotBefore)
-	notAfter = shortFormat(certPair.PreCert.NotAfter)
-	if notBefore != expectedStartDate {
-		t.Errorf("preCert notBefore was %q, expected %q",
-			notBefore, expectedStartDate)
-	}
-	if notAfter != expectedEndDate {
-		t.Errorf("preCert notAfter was %q, expected %q",
-			notAfter, expectedEndDate)
-	}
-	// Check that the cert notbefore/notafter match expected
-	notBefore = shortFormat(certPair.Cert.NotBefore)
-	notAfter = shortFormat(certPair.Cert.NotAfter)
-	if notBefore != expectedStartDate {
-		t.Errorf("cert notBefore was %q, expected %q",
-			notBefore, expectedStartDate)
-	}
-	if notAfter != expectedEndDate {
-		t.Errorf("cert notAfter was %q, expected %q",
-			notAfter, expectedEndDate)
 	}
 }


### PR DESCRIPTION
If windowStart/windowEnd were defined, an issued
cert would be created with notBefore/notAfter
set close to those same values. This would cause
problems issuing to a shard that wouldn't accept
certs dated in the future (which is Trillian's
behavior with "reject_expired: true").

Now certs issued for sharded logs, notBefore is
set to now and notAfter set to ~windowEnd, except
when windowEnd is in the past. In that case the
cert notBefore is backdated 90 days from windowEnd.

Fixes #99 