### PR TITLE
cert-submitter: allow custom base domain.

### DIFF
--- a/examples/config.dist.json
+++ b/examples/config.dist.json
@@ -9,7 +9,8 @@
     "interval": "600s",
     "timeout": "500s",
     "certIssuerKeyPath": "/etc/ct-woodpecker/issuer.key",
-    "certIssuerPath": "/etc/ct-woodpecker/issuer.pem"
+    "certIssuerPath": "/etc/ct-woodpecker/issuer.pem",
+    "baseDomain": ".example.com"
   },
   "inclusionConfig": {
     "interval": "60s",

--- a/monitor/cert_submitter_test.go
+++ b/monitor/cert_submitter_test.go
@@ -373,6 +373,31 @@ func TestSubmitterOptions(t *testing.T) {
 				WindowEnd:   &goodEnd,
 			},
 		},
+		{
+			Name: "Invalid base domain",
+			Opts: SubmitterOptions{
+				Interval:    time.Second * 10,
+				Timeout:     time.Second * 10,
+				IssuerKey:   k,
+				IssuerCert:  cert,
+				WindowStart: &goodStart,
+				WindowEnd:   &goodEnd,
+				BaseDomain:  "aaaa",
+			},
+			ExpectedError: "BaseDomain must start with a '.' character",
+		},
+		{
+			Name: "Good base domain",
+			Opts: SubmitterOptions{
+				Interval:    time.Second * 10,
+				Timeout:     time.Second * 10,
+				IssuerKey:   k,
+				IssuerCert:  cert,
+				WindowStart: &goodStart,
+				WindowEnd:   &goodEnd,
+				BaseDomain:  ".my.base.domain.example.com",
+			},
+		},
 	}
 	for _, tc := range testCases {
 		t.Run(tc.Name, func(t *testing.T) {

--- a/test/config/ct-woodpecker.localdev.json
+++ b/test/config/ct-woodpecker.localdev.json
@@ -10,7 +10,8 @@
     "interval": "5s",
     "timeout": "5s",
     "certIssuerKeyPath": "test/issuer.key",
-    "certIssuerPath": "test/issuer.pem"
+    "certIssuerPath": "test/issuer.pem",
+    "baseDomain": ".local.dev"
   },
   "inclusionConfig": {
     "interval": "30s",


### PR DESCRIPTION
Previously the base domain for all the test certificate subjects was
a static string specific to Let's Encrypt. Allowing this base domain to
be configured in the cert submitter config will help outside
organizations use this tool with their own logs.

Resolves https://github.com/letsencrypt/ct-woodpecker/issues/105