### PR TITLE
CI: switch to Go 1.13, update golangci-lint, avoid module download.

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -20,6 +20,7 @@ linters:
     - gocritic
     - gochecknoinits
     - gochecknoglobals
+    - typecheck # Go 1.13 incompatible pending new golangci-lint binary release
 
 issues:
   exclude:

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ language: go
 sudo: true
 
 go:
-  - "1.12.x"
+  - "1.13.x"
 
 env:
   - GO111MODULE=on

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,9 +5,6 @@ sudo: true
 go:
   - "1.13.x"
 
-env:
-  - GO111MODULE=on
-
 install:
   # Install `golangci-lint` using their installer script
   - curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | sh -s -- -b $(go env GOPATH)/bin v1.17.1

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ env:
 
 install:
   # Install `golangci-lint` using their installer script
-  - curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | sh -s -- -b $(go env GOPATH)/bin v1.13.2
+  - curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | sh -s -- -b $(go env GOPATH)/bin v1.17.1
   # Install `cover` and `goveralls` without `GO111MODULE` enabled so that we
   # don't download ct-woodpecker dependencies and just put the tools in our
   # gobin.
@@ -24,7 +24,6 @@ before_script:
 
 script:
   - set -e
-  - go mod download
   - golangci-lint run
   - docker-compose up -d mysql
   - go test -mod=vendor -v -race -covermode=atomic -coverprofile=coverage.out -tags=integration ./...


### PR DESCRIPTION
One of the transitive dependencies of `ct-woodpecker` seems to have moved/gone away causing consistent build failures of the form:
```
go: git.apache.org/thrift.git@v0.0.0-20180902110319-2566ecd5d999: git fetch -f origin refs/heads/*:refs/heads/* refs/tags/*:refs/tags/* in /home/travis/gopath/pkg/mod/cache/vcs/83dba939f95a790e497d565fc4418400145a1a514f955fa052f662d56e920c3e: exit status 128:
	fatal: unable to access 'https://git.apache.org/thrift.git/': Failed to connect to git.apache.org port 443: Connection timed out
```
We already vendor dependencies to avoid this sort of problem. The easiest "fix" in this case was to remove a workaround `go mod download` we did to appease earlier `golangci-lint` versions.

In short:
* Updated to Go 1.13 (why not)
* Updated `golangci-lint`
* Removed `go mod download`.
* Removed unneeded `GO111MODULE=on` env var