### PR TITLE
Fix broken repo logo image source

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # CT Woodpecker
 
-<p align="center">
-  <img src="https://raw.githubusercontent.com/letsencrypt/ct-woodpecker/main/logo.jpg" height="100" alt="ct-woodpecker: poking holes in logs"/>
+<p align="left">
+  <img src="https://raw.githubusercontent.com/letsencrypt/ct-woodpecker/main/logo.jpg" height="200" alt="ct-woodpecker: poking holes in logs"/>
 <p>
 
 [![Build Status](https://travis-ci.org/letsencrypt/ct-woodpecker.svg?branch=master)](https://travis-ci.org/letsencrypt/ct-woodpecker)

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # CT Woodpecker
 
 <p align="center">
-  <img src="https://raw.githubusercontent.com/letsencrypt/ct-woodpecker/main/logo.jpg" alt="ct-woodpecker: poking holes in logs"/>
+  <img src="https://raw.githubusercontent.com/letsencrypt/ct-woodpecker/main/logo.jpg" height="100" alt="ct-woodpecker: poking holes in logs"/>
 <p>
 
 [![Build Status](https://travis-ci.org/letsencrypt/ct-woodpecker.svg?branch=master)](https://travis-ci.org/letsencrypt/ct-woodpecker)

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # CT Woodpecker
 
 <p align="center">
-  <img src="https://github.com/letsencrypt/ct-woodpecker/raw/master/logo.jpg" alt="ct-woodpecker: poking holes in logs"/>
+  <img src="https://raw.githubusercontent.com/letsencrypt/ct-woodpecker/main/logo.jpg" alt="ct-woodpecker: poking holes in logs"/>
 <p>
 
 [![Build Status](https://travis-ci.org/letsencrypt/ct-woodpecker.svg?branch=master)](https://travis-ci.org/letsencrypt/ct-woodpecker)


### PR DESCRIPTION
Can see what this looks like on [my fork here](https://github.com/leonstafford/ct-woodpecker/).

Fixes #124 