### PR TITLE
Use 90 day test certs in temporal shard window

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -8,6 +8,8 @@ on:
   pull_request:
     branches:
       - '*'
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
 permissions:
   contents: read
   pull-requests: read
@@ -16,11 +18,11 @@ jobs:
     name: lint
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/setup-go@v2
-      - uses: actions/checkout@v2
+      - uses: actions/setup-go@v4
+      - uses: actions/checkout@v3
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v2
+        uses: golangci/golangci-lint-action@v3
         with:
-          version: v1.45.2
+          version: latest
           args: --timeout 9m
           only-new-issues: true

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,7 +5,8 @@ on:
     branches: [ main ]
   pull_request:
     branches: [ main ]
-
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
 jobs:
   test:
     runs-on: ubuntu-latest
@@ -15,7 +16,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v3
       with:
-        go-version: 1.17
+        go-version: 1.20.2
 
     - name: Install cover
       run: go install golang.org/x/tools/cmd/cover@latest

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -18,6 +18,6 @@ linters-settings:
     checks: ["all", "-ST1005"]
   gosec:
     excludes:
-      # TODO: Identify, fix, and remove violations of most of these rules
+      # TODO(#133): Identify, fix, and remove violations of most of these rules
       - G112 # Potential Slowloris Attack because ReadHeaderTimeout is not configured in the http.Server (gosec)
       - G404 # Use of weak random number generator (math/rand instead of crypto/rand)

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -12,3 +12,12 @@ linters:
     - stylecheck
     - unconvert
     - unused 
+linters-settings:
+  stylecheck:
+    # ST1005: Incorrectly formatted error string
+    checks: ["all", "-ST1005"]
+  gosec:
+    excludes:
+      # TODO: Identify, fix, and remove violations of most of these rules
+      - G112 # Potential Slowloris Attack because ReadHeaderTimeout is not configured in the http.Server (gosec)
+      - G404 # Use of weak random number generator (math/rand instead of crypto/rand)

--- a/monitor/sth_fetcher.go
+++ b/monitor/sth_fetcher.go
@@ -203,16 +203,21 @@ func (f *sthFetcher) observeSTH() {
 // firstSTH and secondSTH. If the two STHs don't verify then the
 // `sth_inconsistencies` prometheus counter is incremented with a label
 // indicating the category of inconsistency and an error is logged with
-// `logErrorf`. Presently there are three possible categories of STH consistency
-// failure:
-// 1. "equal-treesize-inequal-hash" - the two STHs are the same tree size but
-//    have different root hashes.
-// 2. "failed-to-get-proof" - the monitor encountered an error getting
-//    a consistency proof between the two STHs from the log.
-// 3. "failed-to-verify-proof" - the monitor returned a proof of consistency
-//    between the two STHs that did not verify.
-// When the monitor fetches a consistency proof from the log it publishes the
-// latency of the operation to the `sth_proof_latency` prometheus histogram.
+// `logErrorf`. Presently there are three possible categories of STH
+// consistency failure:
+//
+// 1. "equal-treesize-inequal-hash" - the two STHs are the same tree size
+// but have different root hashes.
+//
+// 2. "failed-to-get-proof" - the monitor encountered an error getting a
+// consistency proof between the two STHs from the log.
+//
+// 3. "failed-to-verify-proof" - the monitor returned a proof of
+// consistency between the two STHs that did not verify.
+//
+// When the monitor fetches a consistency proof from the log it publishes
+// the latency of the operation to the `sth_proof_latency` prometheus
+// histogram.
 func (f *sthFetcher) verifySTHConsistency(firstSTH, secondSTH *ct.SignedTreeHead) {
 	if firstSTH == nil || secondSTH == nil {
 		f.logErrorf("firstSTH or secondSTH was nil")

--- a/pki/certs.go
+++ b/pki/certs.go
@@ -101,23 +101,29 @@ type CertificatePair struct {
 	Cert    *x509.Certificate
 }
 
-// IssueTestCertificate uses the monitor's certIssuer and certIssuerKey to generate
-// a precertificate and a matching final leaf-certificate that can be submitted
-// to a log. The certificate's subject common name will be a random subdomain
-// based on the certificate serial under the provided baseDomain (or
-// defaultTestCertDomain domain if baseDomain is empty).
+// IssueTestCertificate uses the monitor's certIssuer and certIssuerKey to
+// generate a precertificate and a matching final leaf-certificate that
+// can be submitted to a log. The certificate's subject common name will
+// be a random subdomain based on the certificate serial under the
+// provided baseDomain (or defaultTestCertDomain domain if baseDomain is
+// empty).
 //
-// If windowStart is nil the certificate NotBefore will be set to the current
-// time based on the provided clock. If windowStart is not nil then the
-// certificate NotBefore will be set to the windowStart plus one day.
-
-// If windowEnd is nil the certificate NotAfter will be set to 90 days after the
-// current time based on the provided clock. If windowEnd is not nil then the
-// certificate NotAfter will be set to the windowEnd minus one day.
+// If windowStart is nil the certificate NotBefore will be set to the
+// current time based on the provided clock.
 //
-// This function creates certificates that will be submitted to public logs and
-// so while they are not issued by a trusted root  we try to avoid cablint
-// errors to avoid requiring log monitors special-case our submissions.
+// If windowEnd is nil the certificate NotAfter will be set to 90 days
+// after the current time based on the provided clock.
+//
+// If windowStart and windowEnd are not nil then issue a 90 day
+// certificate that falls in the window.
+//
+// with a NotAfter of `windowEnd - 1 hour` and a NotBefore
+// 90 days earlier.
+//
+// This function creates certificates that will be submitted to public
+// logs and so while they are not issued by a trusted root  we try to
+// avoid cablint errors to avoid requiring log monitors special-case our
+// submissions.
 func IssueTestCertificate(
 	baseDomain string,
 	issuerKey *ecdsa.PrivateKey,
@@ -141,16 +147,17 @@ func IssueTestCertificate(
 		return CertificatePair{}, err
 	}
 
-	earliest := clk.Now()
-	latest := earliest.AddDate(0, 0, 90)
+	notBefore := clk.Now()
+	notAfter := notBefore.AddDate(0, 0, 90)
 
-	if windowStart != nil {
-		earliest = *windowStart
-		earliest.AddDate(0, 0, 1)
-	}
+	// If `notAfter` generated from the system clock doesn't fall within the
+	// temporal shard window then we need to adjust the certificate validity
+	// to fall within the window.
 	if windowEnd != nil {
-		latest = *windowEnd
-		latest.AddDate(0, 0, -1)
+		if notAfter.Before(*windowStart) || notAfter.After(*windowEnd) {
+			notAfter = windowEnd.Add(-1 * time.Hour)
+			notBefore = notAfter.AddDate(0, 0, -90)
+		}
 	}
 
 	domain := hex.EncodeToString(serial.Bytes()[:5]) + baseDomain
@@ -162,8 +169,8 @@ func IssueTestCertificate(
 			},
 			DNSNames:              []string{domain},
 			SerialNumber:          serial,
-			NotBefore:             earliest,
-			NotAfter:              latest.AddDate(0, 0, -1),
+			NotBefore:             notBefore,
+			NotAfter:              notAfter,
 			KeyUsage:              x509.KeyUsageDigitalSignature,
 			ExtKeyUsage:           []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth, x509.ExtKeyUsageClientAuth},
 			BasicConstraintsValid: true,

--- a/test/cttestsrv/log.go
+++ b/test/cttestsrv/log.go
@@ -11,7 +11,6 @@ import (
 	"time"
 
 	ct "github.com/google/certificate-transparency-go"
-	"github.com/google/certificate-transparency-go/tls"
 	cttls "github.com/google/certificate-transparency-go/tls"
 	ctfe "github.com/google/certificate-transparency-go/trillian/ctfe"
 	"github.com/google/certificate-transparency-go/trillian/util"
@@ -99,7 +98,7 @@ func makeTree(name string, _ *ecdsa.PrivateKey) (*testTree, error) {
 
 	// initialize the tree with an empty STH
 	if err := initSTH(tt); err != nil {
-		return nil, fmt.Errorf("initalizing STH: %w", err)
+		return nil, fmt.Errorf("initializing STH: %w", err)
 	}
 
 	return tt, nil
@@ -111,14 +110,14 @@ func initSTH(tt *testTree) error {
 
 	// init the new tree by signing a STH for the empty root
 	slr := types.LogRoot{
-		Version: tls.Enum(trillian.LogRootFormat_LOG_ROOT_FORMAT_V1),
+		Version: cttls.Enum(trillian.LogRootFormat_LOG_ROOT_FORMAT_V1),
 		V1: &types.LogRootV1{
 			TreeSize:       0,
 			RootHash:       emptyRootHash[:],
 			TimestampNanos: uint64(timeSource.Now().UnixNano()),
 		},
 	}
-	slrBytes, err := tls.Marshal(slr)
+	slrBytes, err := cttls.Marshal(slr)
 	if err != nil {
 		return err
 	}
@@ -239,7 +238,7 @@ func (tl *testLog) getSTH() (*ct.SignedTreeHead, error) {
 	}
 
 	var slr ct.SignedTreeHead
-	_, err = tls.Unmarshal(signedLogRoot.LogRoot, &slr)
+	_, err = cttls.Unmarshal(signedLogRoot.LogRoot, &slr)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Change the behavior of the test certificate generation to always create a
90 day certificate, and make sure it falls in the temporal shard window if
one is defined. If issuing a certificate for a current temporal shard
(where the system time + 90d `NotAfter` lands in the temporal window),
then generate a certifcate based on the current time. If generating a
certificate for a past or future temporal shard, then generate a 90d
certificate that falls in that window.

In addition, fix failing CI with updates and lint fixes:
* Update golangci-lint
* Add the ability to run tests and lint manually in GitHub Actions
* Add lint exclusions
* Fix misspelling
* Remove duplicate tls import

Fixes #127