### PR TITLE
Update container mariadb to percona-server 8.0

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -42,7 +42,7 @@ services:
       - mysql
 
   mysql:
-      image: mariadb:10.3
+      image: percona/percona-server:8.0
       volumes:
           # Mount the directory containing the schema; The schema will be run at
           # initialization time.


### PR DESCRIPTION
Let's Encrypt uses percona-xtradb-cluster as the database backend for ct-woodpecker. Upgrade from mariadb 10.3 to the latest percona-server version.