### PR TITLE
Remove status badges from README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,10 +4,6 @@
   <img src="https://github.com/letsencrypt/ct-woodpecker/raw/main/logo.jpg" alt="ct-woodpecker: poking holes in logs"/>
 <p>
 
-[![Coverage Status](https://coveralls.io/repos/github/letsencrypt/ct-woodpecker/badge.svg?branch=cpu-goveralls)](https://coveralls.io/github/letsencrypt/ct-woodpecker?branch=cpu-goveralls)
-[![Go Report Card](https://goreportcard.com/badge/github.com/letsencrypt/ct-woodpecker)](https://goreportcard.com/report/github.com/letsencrypt/ct-woodpecker)
-[![GolangCI](https://golangci.com/badges/github.com/letsencrypt/ct-woodpecker.svg)](https://golangci.com/r/github.com/letsencrypt/ct-woodpecker)
-
 `ct-woodpecker` pokes holes in logs and finds bugs. It is a tool for monitoring
 a [Certificate Transparency][ct] log for operational problems.
 


### PR DESCRIPTION
These status badges are not super useful at best, and broken at worst.